### PR TITLE
Add MANIFEST to include headers

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+graft source/VBBL
+graft source/AdaptiveContouring


### PR DESCRIPTION
Fixes VBBL and AdaptiveContour import error when installing the source distribution from PyPI.

I recommend manually running `python setup.py sdist` and `twine upload ...` to some dummy version or to TestPyPI and try installing it.