### PR TITLE
Add manylinux binary distributions to publish GH action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,10 +3,41 @@ name: Upload Python Package to PyPI
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      disable_publish:
+        description: "Disable publish to PyPI"
+        required: false
+        type: boolean
+        default: false
 
 jobs:
-  publish:
+  build_binary_manylinux:
+    runs-on: ubuntu-latest
+    container: quay.io/pypa/manylinux_2_24_x86_64
 
+    strategy:
+      matrix:
+        python-version:
+          - cp37-cp37m
+          - cp38-cp38
+          - cp39-cp39
+          - cp310-cp310
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Build Python wheels
+      env:
+        PYTHON_VERSION: ${{ matrix.python-version }}
+      run: |
+         /opt/python/$PYTHON_VERSION/bin/python -m build --wheel
+
+    - uses: actions/upload-artifact@v2
+      with:
+        path: ${{ github.workspace }}/dist/*.whl
+
+  build_source:
     runs-on: ubuntu-latest
 
     steps:
@@ -15,7 +46,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.9"
+        python-version: "3.10"
 
     - name: Install dependencies
       run: |
@@ -24,6 +55,22 @@ jobs:
 
     - name: Build package
       run: python setup.py sdist
+
+    - uses: actions/upload-artifact@v2
+      with:
+        path: ${{ github.workspace }}/dist/*.tar.gz
+
+  publish:
+    needs: [build_source, build_binary_manylinux]
+    if: github.event.inputs.disable_publish == 0
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: actions/download-artifact@v2
+      with:
+        path: ${{ github.workspace }}/dist/
 
     - name: Publish package to PyPI
       # All files in dist/ are published


### PR DESCRIPTION
## Changes
* The GH action `publish.yml` is now three actions:
  1. Build manylinux wheels binary distribution
  2. Build source distribution 
  3. Publish (1) and (2) to PyPI in one go
* Add manylinux wheel builds for only x86_64 architecture
  * Supported only for Python 3.7&ndash;3.10. 
* The GH action now creates artifact, a zip file with all distributions
* Add a manual way to run publish without needing to trigger via a github release. 
  * On manual run, you may disable publish to PyPI. This could be useful to debug any distribution by downloading the GH action artifact.

## TODO for Reviewers
- [ ] Are there any other linux cpu architecture we must support?
- [ ] After merging, try to trigger a manual run (**make sure to disable publish!**). When it's done, there should be an artifact you can download. Unzip this and do a pip install on the binary and source distribution (each in its own environment is preferable).
    ![image](https://user-images.githubusercontent.com/13506487/153939237-7509a875-7781-4ec9-9ffc-4e123336e939.png)
    `-----------------`
    ![image](https://user-images.githubusercontent.com/13506487/153939372-5ab56a98-dbbe-4a48-86e0-05dbd3f38ede.png) 
- [ ] Trigger a run by a github release. Once the run finishes and the new version is in PyPI, then using a linux x86 machine, run `pip install MulensModel`. This should automatically detect the binary distribution (i.e., a `.whl` file should be downloaded and not `.tar.gz`).
