### PR TITLE
Revert binary distribution

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,34 +5,8 @@ on:
     types: [published]
 
 jobs:
-  build_binary_manylinux:
-    runs-on: ubuntu-latest
-    container: quay.io/pypa/manylinux_2_24_x86_64
+  publish:
 
-    strategy:
-      matrix:
-        python-version:
-          - cp37-cp37m
-          - cp38-cp38
-          - cp39-cp39
-          - cp310-cp310
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Build Python wheels
-      env:
-        PYTHON_VERSION: ${{ matrix.python-version }}
-      run: |
-         /opt/python/$PYTHON_VERSION/bin/python -m build --wheel
-
-    - uses: actions/upload-artifact@v2
-      with:
-        name: dist
-        path: dist/*.whl
-
-
-  build_source:
     runs-on: ubuntu-latest
 
     steps:
@@ -41,7 +15,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: "3.9"
 
     - name: Install dependencies
       run: |
@@ -50,23 +24,6 @@ jobs:
 
     - name: Build package
       run: python setup.py sdist
-
-    - uses: actions/upload-artifact@v2
-      with:
-        name: dist
-        path: dist/*.tar.gz
-
-  publish:
-    needs: [build_source, build_binary_manylinux]
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - uses: actions/download-artifact@v2
-      with:
-        name: dist
-        path: dist/
 
     - name: Publish package to PyPI
       # All files in dist/ are published


### PR DESCRIPTION
I'm reverting all changes to `publish.yml` to 8afa01bcb975ba51730ac6b557cf81b53218e865. 

I've come to found even using PyPA's own manylinux tool is not enough and you have to use the old `manylinux1` over `manylinux2014`. This instruction was only ever mentioned officially in [PEP 513](https://www.python.org/dev/peps/pep-0513/#id44) (and not in PyPI's FAQ or docs).

I will have to play with a forked repo and a `test.pypi.org` package to do this better.