### PR TITLE
Add wheel distribution for musl, MacOS, and Python 3.11

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,17 +16,15 @@ jobs:
         # A matrix of OSs, Python verisons, and architectures
         # Skips PyPy
         os: [ubuntu-latest, macos-latest]
+        cw_archs: [auto64]
         cw_build: [cp37-*, cp38-*, cp39-*, cp310-*, cp311-*]
+        cw_skip: [pp*]
         include:
-        # Linux x86_64
-        - {os: ubuntu-latest, cw_archs: x86_64, cw_skip: "pp* *_i686"}         
-        # MacOS Intel
-        - {os: macos-latest, cw_archs: "x86_64", cw_skip: "pp*"}
-        # MacOS Silicon
-        - {os: macos-latest, cw_archs: "arm64", cw_skip: "pp*"}
-        exclude:
-        # Skips MacOS Silicon for Python 3.7 (wheel metadata does not exist)
-        - {os: macos-latest, cw_build: "cp3.7"}
+        # MacOS Silicon (Python >= 3.8)
+        - {os: macos-latest, cw_archs: "arm64", cw_build: "cp38-*"}
+        - {os: macos-latest, cw_archs: "arm64", cw_build: "cp39-*"}
+        - {os: macos-latest, cw_archs: "arm64", cw_build: "cp310-*"}
+        - {os: macos-latest, cw_archs: "arm64", cw_build: "cp311-*"}
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,8 +22,11 @@ jobs:
         - {os: ubuntu-latest, cw_archs: x86_64, cw_skip: "pp* *_i686"}         
         # MacOS Intel
         - {os: macos-latest, cw_archs: "x86_64", cw_skip: "pp*"}
-        # MacOS Silicon (>= Python 3.8 only)
-        - {os: macos-latest, cw_archs: "arm64", cw_build: "cp38-*, cp39-*, cp310-*, cp311-*", cw_skip: "pp*"}
+        # MacOS Silicon
+        - {os: macos-latest, cw_archs: "arm64", cw_skip: "pp*"}
+        exclude:
+        # Skips MacOS Silicon for Python 3.7 (wheel metadata does not exist)
+        - {os: macos-latest, cw_build: "3.7", cw_archs: "arm64", cw_skip: "pp*"}
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
         include:
         - {os: ubuntu-latest, cw_archs: x86_64, skip: "pp* *_i686"}  # 64-bit Linux
         - {os: macos-latest, cw_archs: "x86_64", skip: "pp*"}        # MacOS Intel
-        - {os: macos-latest, cw_archs: "arm64", skip: "pp*"}         # MacOS Silicon
+        - {os: macos-latest, cw_archs: "arm64", build: "cp311-*", skip: "pp*"}         # MacOS Silicon
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,12 +13,17 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        # A matrix of OSs, Python verisons, and architectures
+        # Skips PyPy
         os: [ubuntu-latest, macos-latest]
         cw_build: [cp37-*, cp38-*, cp39-*, cp310-*, cp311-*]
         include:
-        - {os: ubuntu-latest, cw_archs: x86_64, skip: "pp* *_i686"}  # 64-bit Linux
-        - {os: macos-latest, cw_archs: "x86_64", skip: "pp*"}        # MacOS Intel
-        - {os: macos-latest, cw_archs: "arm64", build: "cp311-*", skip: "pp*"}         # MacOS Silicon
+        # Linux x86_64
+        - {os: ubuntu-latest, cw_archs: x86_64, cw_skip: "pp* *_i686"}         
+        # MacOS Intel
+        - {os: macos-latest, cw_archs: "x86_64", cw_skip: "pp*"}
+        # MacOS Silicon (>= Python 3.8 only)
+        - {os: macos-latest, cw_archs: "arm64", cw_build: "cp38-*, cp39-*, cp310-*, cp311-*", cw_skip: "pp*"}
 
     steps:
       - uses: actions/checkout@v3
@@ -28,6 +33,7 @@ jobs:
         env:
           CIBW_ARCHS: ${{ matrix.cw_archs }}
           CIBW_BUILD: ${{ matrix.cw_build }}
+          CIBW_SKIP: ${{ matrix.cw_skip }}
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,57 +1,48 @@
 # This workflow is triggered by a new release on GitHub and then uploads
 # MulensModel package to PyPI.
-#
-# If the publish step finishes succesfully, the source distribution is
-# guaranteed to be published. Binary distributions are published only if
-# their respective build steps passes. If any binary distribution fails,
-# package maintainers may manually debug, build, and publish without the
-# automated workflow.
 name: Upload Python Package to PyPI
 
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
-  build_binary_manylinux:
-    runs-on: ubuntu-latest
-    container: quay.io/pypa/manylinux_2_24_x86_64
-
+  build_wheels:
+    name: Build wheel [${{ matrix.os }} ${{ matrix.cw_archs }} ${{ matrix.cw_build }}]
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version:
-          - cp37-cp37m
-          - cp38-cp38
-          - cp39-cp39
-          - cp310-cp310
+        os: [ubuntu-latest, macos-latest]
+        cw_build: [cp37-*, cp38-*, cp39-*, cp310-*, cp311-*]
+        include:
+        - {os: ubuntu-latest, cw_archs: x86_64, skip: "pp* *_i686"}  # 64-bit Linux
+        - {os: macos-latest, cw_archs: "x86_64", skip: "pp*"}        # MacOS Intel
+        - {os: macos-latest, cw_archs: "arm64", skip: "pp*"}         # MacOS Silicon
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-    - name: Build Python wheels
-      # Build linux wheels with the image then use auditwheel
-      # to convert to it a manylinux wheel.
-      env:
-        PYTHON_VERSION: ${{ matrix.python-version }}
-      run: |
-         /opt/python/$PYTHON_VERSION/bin/python -m build --wheel
-         find dist/ -type f -name *.whl | xargs -L 1 auditwheel repair --wheel-dir dist/
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.11.2
+        env:
+          CIBW_ARCHS: ${{ matrix.cw_archs }}
+          CIBW_BUILD: ${{ matrix.cw_build }}
 
-    - uses: actions/upload-artifact@v2
-      # Only upload manylinux wheels to artifact.
-      # Normal linux wheels is not allowed in PyPI
-      with:
-        name: dist
-        path: dist/*manylinux*.whl
+      - uses: actions/upload-artifact@v3
+        with:
+          name: bdist
+          path: ./wheelhouse/*.whl
 
   build_source:
+    name: Build sdist
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: "3.10"
 
@@ -65,21 +56,20 @@ jobs:
 
     - uses: actions/upload-artifact@v2
       with:
-        name: dist
-        path: dist/*.tar.gz
+        name: sdist
+        path: ./dist/*.tar.gz
 
   publish:
-    # Publish to PyPI and update GitHub release
-    # Here we require only the source build to start publishing
-    needs: [build_source]
+    name: Publish to PyPI
     runs-on: ubuntu-latest
+    needs: [build_source, build_wheels]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
-    - uses: actions/download-artifact@v2
+    - name: Download all artifacts to dist/
+      uses: actions/download-artifact@v3
       with:
-        name: dist
         path: dist/
 
     - name: Publish package to PyPI

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
         - {os: macos-latest, cw_archs: "arm64", cw_skip: "pp*"}
         exclude:
         # Skips MacOS Silicon for Python 3.7 (wheel metadata does not exist)
-        - {os: macos-latest, cw_build: "3.7", cw_archs: "arm64", cw_skip: "pp*"}
+        - {os: macos-latest, cw_build: "cp3.7"}
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build_wheels:
-    name: Build wheel [${{ matrix.os }} ${{ matrix.cw_archs }} ${{ matrix.cw_build }}]
+    name: ${{ matrix.os }} ${{ matrix.cw_archs }} ${{ matrix.cw_build }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,22 +9,22 @@ on:
 
 jobs:
   build_wheels:
-    name: ${{ matrix.os }} ${{ matrix.cw_archs }} ${{ matrix.cw_build }}
+    name: ${{ matrix.os }} ${{ matrix.cibw_archs }} ${{ matrix.cw_build }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         # A matrix of OSs, Python verisons, and architectures
         # Skips PyPy
         os: [ubuntu-latest, macos-latest]
-        cw_archs: [auto64]
-        cw_build: [cp37-*, cp38-*, cp39-*, cp310-*, cp311-*]
-        cw_skip: [pp*]
+        cibw_archs: [auto64]
+        cibw_build: [cp37-*, cp38-*, cp39-*, cp310-*, cp311-*]
+        cibw_skip: [pp*]
         include:
         # MacOS Silicon (Python >= 3.8)
-        - {os: macos-latest, cw_archs: "arm64", cw_build: "cp38-*"}
-        - {os: macos-latest, cw_archs: "arm64", cw_build: "cp39-*"}
-        - {os: macos-latest, cw_archs: "arm64", cw_build: "cp310-*"}
-        - {os: macos-latest, cw_archs: "arm64", cw_build: "cp311-*"}
+        - {os: macos-latest, cibw_archs: "arm64", cw_build: "cp38-*"}
+        - {os: macos-latest, cibw_archs: "arm64", cw_build: "cp39-*"}
+        - {os: macos-latest, cibw_archs: "arm64", cw_build: "cp310-*"}
+        - {os: macos-latest, cibw_archs: "arm64", cw_build: "cp311-*"}
 
     steps:
       - uses: actions/checkout@v3
@@ -32,9 +32,9 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.11.2
         env:
-          CIBW_ARCHS: ${{ matrix.cw_archs }}
-          CIBW_BUILD: ${{ matrix.cw_build }}
-          CIBW_SKIP: ${{ matrix.cw_skip }}
+          CIBW_ARCHS: ${{ matrix.cibw_archs }}
+          CIBW_BUILD: ${{ matrix.cibw_build }}
+          CIBW_SKIP: ${{ matrix.cibw_skip }}
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,7 +60,7 @@ jobs:
     - name: Build package
       run: python setup.py sdist
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: sdist
         path: ./dist/*.tar.gz

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,7 @@ jobs:
 
       - uses: actions/upload-artifact@v3
         with:
-          name: bdist
+          name: wheelhouse
           path: ./wheelhouse/*.whl
 
   build_source:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,3 @@
 [build-system]
-requires = [
-    "setuptools",
-    "wheel"
-]
+requires = ["setuptools"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
I've extended the package building CI to include wheels for Python 3.11, Linux musl (e.g., Apline OS), and MacOS (both Intel and Silicon). In total there are 19 wheels in the following matrix:

- 5 Linux; Python 3.7-3.11
- 5 Linux musl; Python 3.7-3.11
- 5 MacOS Intel; Python 3.7-3.11
- 4 MacOS Silicon; Python 3.8-3.11  (3.7 wheels is not available for Silicon)

A few other key changes are highlighted in the comments below.

---

BTW, here are the badges for MulensModel connected to PyPI. They may look nice in the repository README.

  * [![PyPI version](https://badge.fury.io/py/MulensModel.svg)](https://badge.fury.io/py/MulensModel)
  * ![PyPI - Downloads](https://img.shields.io/pypi/dm/MulensModel)
