### PR TITLE
Fix publish artifacts to PyPI due to directory names

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -74,16 +74,21 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Download all artifacts to dist/
+    - name: Download sdist artifacts to dist/
       uses: actions/download-artifact@v3
       with:
+        name: sdist
         path: dist/
 
-    - run: "ls -a dist/"
+    - name: Download wheelhouse artifacts to dist/
+      uses: actions/download-artifact@v3
+      with:
+        name: wheelhouse
+        path: dist/
 
-    # - name: Publish package to PyPI
-    #   # All files in dist/ are published
-    #   uses: pypa/gh-action-pypi-publish@release/v1
-    #   with:
-    #     user: __token__
-    #     password: ${{ secrets.PYPI_API_TOKEN }}
+    - name: Publish package to PyPI
+      # All files in dist/ are published
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build_wheels:
-    name: ${{ matrix.os }} ${{ matrix.cibw_archs }} ${{ matrix.cw_build }}
+    name: ${{ matrix.os }} ${{ matrix.cibw_archs }} ${{ matrix.cibw_build }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -79,9 +79,11 @@ jobs:
       with:
         path: dist/
 
-    - name: Publish package to PyPI
-      # All files in dist/ are published
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
+    - run: "ls -a dist/"
+
+    # - name: Publish package to PyPI
+    #   # All files in dist/ are published
+    #   uses: pypa/gh-action-pypi-publish@release/v1
+    #   with:
+    #     user: __token__
+    #     password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
The issue was in this step artifacts are downloaded and exported like 

```
dist/
  sdist/
    MulensModel*.tar.gz
  wheelhouse/
     MulensModel*.whl
```

when we needed

```
dist/
  MulensModel*.tar.gz
  MulensModel*.whl
```

My mistake. Tested this to work.

To redo the release, I recommend to just re-point v2.15.0 to this PR's commit (after merge) since there are no library changes and v2.15.0 never made it to PyPI anyways.