### PR TITLE
Bugfix improve example16

### DIFF
--- a/examples/example_16/ob03235_2_full.yaml
+++ b/examples/example_16/ob03235_2_full.yaml
@@ -87,8 +87,7 @@ plots:
             # magnifications: optimal
             # If you don't know what will be the range of magnifications on your plot, then make
             # a test run with some very small and very large values and a warning will tell you
-            # what is exact range. Another option is to set it to "optimal", where this range
-            # will be obtained automatically, but labels cannot be given in this case.
+            # what is exact range. If "optimal" is provided, labels can not be given.
             labels: [a, b, c, d, e, f, g, h]
             # If you remove the line above, then magnification values will be printed.
             label: What is shown on this axis?

--- a/examples/example_16/ob03235_2_full.yaml
+++ b/examples/example_16/ob03235_2_full.yaml
@@ -86,9 +86,8 @@ plots:
             magnifications: [2, 3, 4, 5, 6, 7, 8, 9]
             # If you don't know what will be the range of magnifications on your plot, then make
             # a test run with some very small and very large values and a warning will tell you
-            # what is exact range on the plot. Another option is to set the following option to
-            # True, so that the magnification range is calculated automatically:
-            recalculate magnification ticks: True
+            # what is exact range. Another option is to set it to "optimal", where this range
+            # will be obtained automatically, but labels cannot be given in this case.
             labels: [a, b, c, d, e, f, g, h]
             # If you remove the line above, then magnification values will be printed.
             label: What is shown on this axis?

--- a/examples/example_16/ob03235_2_full.yaml
+++ b/examples/example_16/ob03235_2_full.yaml
@@ -84,6 +84,7 @@ plots:
         second Y scale:
         # This adds second Y axis on the right-hand side. Only first line below is required.
             magnifications: [2, 3, 4, 5, 6, 7, 8, 9]
+            # magnifications: optimal
             # If you don't know what will be the range of magnifications on your plot, then make
             # a test run with some very small and very large values and a warning will tell you
             # what is exact range. Another option is to set it to "optimal", where this range

--- a/examples/example_16/ob03235_2_full.yaml
+++ b/examples/example_16/ob03235_2_full.yaml
@@ -86,7 +86,9 @@ plots:
             magnifications: [2, 3, 4, 5, 6, 7, 8, 9]
             # If you don't know what will be the range of magnifications on your plot, then make
             # a test run with some very small and very large values and a warning will tell you
-            # what is exact range on the plot.
+            # what is exact range on the plot. Another option is to set the following option to
+            # True, so that the magnification range is calculated automatically:
+            recalculate magnification ticks: True
             labels: [a, b, c, d, e, f, g, h]
             # If you remove the line above, then magnification values will be printed.
             label: What is shown on this axis?

--- a/examples/example_16/ob03235_2_full.yaml
+++ b/examples/example_16/ob03235_2_full.yaml
@@ -82,14 +82,14 @@ plots:
             # makes legend in 2 columns
             loc: lower center
         second Y scale:
-        # This adds second Y axis on the right-hand side. Only first line below is required.
-            magnifications: [2, 3, 4, 5, 6, 7, 8, 9]
-            # magnifications: optimal
-            # If you don't know what will be the range of magnifications on your plot, then make
-            # a test run with some very small and very large values and a warning will tell you
-            # what is exact range. If "optimal" is provided, labels can not be given.
-            labels: [a, b, c, d, e, f, g, h]
-            # If you remove the line above, then magnification values will be printed.
+        # This adds second Y axis to the right side. Only magnifications key is required.
+            magnifications: optimal
+            # magnifications: [2, 3, 4, 5, 6, 7, 8, 9]
+            # If you want to provide magnification values but don't know what will be the range
+            # of magnifications on your plot, then make a test with very small and large numbers
+            # and a warning will tell you the exact range.
+            # labels: [a, b, c, d, e, f, g, h]
+            # The list of labels above can not be given if magnifications = "optimal"
             label: What is shown on this axis?
             color: magenta
     trajectory:

--- a/examples/example_16/ulens_model_fit.py
+++ b/examples/example_16/ulens_model_fit.py
@@ -334,6 +334,7 @@ class UlensModelFit(object):
         """
         Check if MulensModel is new enough
         """
+        print('\nMulensModel version:', mm.__version__, end='\n\n')
         if int(mm.__version__.split('.')[0]) < 2:
             raise RuntimeError(
                 "ulens_model_fit.py requires MulensModel in version "
@@ -1118,7 +1119,7 @@ class UlensModelFit(object):
                     warnings.warn(msg)
                 else:
                     raise ValueError("The path provided for posterior (" +
-                                     name + ") exsists and is a directory")
+                                     name + ") exists and is a directory")
             self._posterior_file_name = name[:-4]
             self._posterior_file_fluxes = None
 

--- a/examples/example_16/ulens_model_fit.py
+++ b/examples/example_16/ulens_model_fit.py
@@ -334,8 +334,8 @@ class UlensModelFit(object):
         """
         Check if MulensModel is new enough
         """
-        code_versions = f"{mm.__version__} and {__version__}"
-        print('\nMulensModel and script versions:', code_versions, end='\n\n')
+        code_version = "{:} and {:}".format(mm.__version__, __version__)
+        print('\nMulensModel and script versions:', code_version, end='\n\n')
         if int(mm.__version__.split('.')[0]) < 2:
             raise RuntimeError(
                 "ulens_model_fit.py requires MulensModel in version "
@@ -2312,9 +2312,9 @@ class UlensModelFit(object):
 
         This version works with EMCEE version 2.X and 3.0.
         """
-        lst = [mm.__version__, __version__]
-        code_version = f"MulensModel and example versions: {lst}"
         if self._yaml_results:
+            lst = [mm.__version__, __version__]
+            code_version = "MulensModel and script versions: {:}".format(lst)
             print(code_version, **self._yaml_kwargs)
 
         accept_rate = np.mean(self._sampler.acceptance_fraction)
@@ -2836,6 +2836,9 @@ class UlensModelFit(object):
             kwargs = dict()
             if dpi is not None:
                 kwargs = {'dpi': dpi}
+            if path.isfile(file_name):
+                msg = "Exisiting file " + file_name + " will be overwritten"
+                warnings.warn(msg)
             caller.savefig(file_name, **kwargs)
         plt.close()
 

--- a/examples/example_16/ulens_model_fit.py
+++ b/examples/example_16/ulens_model_fit.py
@@ -3094,6 +3094,7 @@ class UlensModelFit(object):
             warnings.warn(msg.format(np.sum(np.logical_not(mask))))
         A_min = (flux_min - blend_flux) / total_source_flux
         A_max = (flux_max - blend_flux) / total_source_flux
+        ax2 = plt.gca().twinx()
 
         if (np.min(magnifications) < A_min or np.max(magnifications) > A_max or
                 np.any(flux < 0.)):
@@ -3103,19 +3104,19 @@ class UlensModelFit(object):
                    "the second scale is not plotted")
             args = [min(magnifications), max(magnifications),
                     A_min[0], A_max[0]]
-            if settings.get("recalculate magnification ticks") is True:
-                magnifications = np.linspace(A_min[0], A_max[0], 8)
-                magnifications = np.unique(magnifications.round(2))
-                flux = total_source_flux * magnifications.tolist() + blend_flux
-                labels = [str(x) for x in magnifications]
-                print(" - New magnifications:", magnifications)
-            else:
+            if settings.get("recalculate magnification ticks") is not True:
                 warnings.warn(msg.format(*args))
+                ax2.get_yaxis().set_visible(False)
                 return
+            else:
+                ax2.set_ylim(A_min, A_max)
+                ticks = ax2.yaxis.get_ticklocs()[1:-1]
+                flux = total_source_flux * ticks.tolist() + blend_flux
+                max_n = max([len(str(x))-str(x).find('.')-1 for x in ticks])
+                labels = [f"%0.{max_n}f" % x for x in ticks]
 
         ticks = mm.Utils.get_mag_from_flux(flux)
 
-        ax2 = plt.gca().twinx()
         ax2.set_ylabel(label).set_color(color)
         ax2.spines['right'].set_color(color)
         ax2.set_ylim(ylim[0], ylim[1])

--- a/examples/example_16/ulens_model_fit.py
+++ b/examples/example_16/ulens_model_fit.py
@@ -3138,7 +3138,7 @@ class UlensModelFit(object):
         A_min = (flux_min - blend_flux) / total_source_flux
         A_max = (flux_max - blend_flux) / total_source_flux
 
-        return (A_min, A_max, (total_source_flux, blend_flux))
+        return (A_min, A_max, [total_source_flux, blend_flux])
 
     def _second_Y_axis_optimal(self, ax2, A_min, A_max):
         """
@@ -3169,7 +3169,7 @@ class UlensModelFit(object):
         Issue warnings for negative flux or bad range of magnificaitons
         """
         if np.any(flux < 0.):
-            mask = flux > 0.
+            mask = (flux > 0.)
             flux = flux[mask]
             labels = [l for (l, m) in zip(labels, mask) if m]
             msg = ("\n\n{:} label/s on the second Y scale will not be shown "

--- a/examples/example_16/ulens_model_fit.py
+++ b/examples/example_16/ulens_model_fit.py
@@ -710,7 +710,8 @@ class UlensModelFit(object):
         This function assumes that the second Y scale will be plotted.
         """
         settings = self._plots['best model']['second Y scale']
-        allowed = set(['color', 'label', 'labels', 'magnifications'])
+        allowed = set(['color', 'label', 'labels', 'magnifications',
+                       'recalculate magnification ticks'])
         unknown = set(settings.keys()) - allowed
         if len(unknown) > 0:
             raise ValueError(
@@ -3102,8 +3103,15 @@ class UlensModelFit(object):
                    "the second scale is not plotted")
             args = [min(magnifications), max(magnifications),
                     A_min[0], A_max[0]]
-            warnings.warn(msg.format(*args))
-            return
+            if settings.get("recalculate magnification ticks") is True:
+                magnifications = np.linspace(A_min[0], A_max[0], 8)
+                magnifications = np.unique(magnifications.round(2))
+                flux = total_source_flux * magnifications.tolist() + blend_flux
+                labels = [str(x) for x in magnifications]
+                print(" - New magnifications:", magnifications)
+            else:
+                warnings.warn(msg.format(*args))
+                return
 
         ticks = mm.Utils.get_mag_from_flux(flux)
 

--- a/examples/example_16/ulens_model_fit.py
+++ b/examples/example_16/ulens_model_fit.py
@@ -2325,6 +2325,11 @@ class UlensModelFit(object):
             print(out, **self._yaml_kwargs)
         self._extract_posterior_samples_EMCEE()
 
+        if self._yaml_results:
+            print("Fixed parameters:", **self._yaml_kwargs)
+            for (key, value) in self._fixed_parameters.items():
+                print("    {:} : {:}".format(key, value), **self._yaml_kwargs)
+
         print("Fitted parameters:")
         self._print_results(self._samples_flat)
         if self._yaml_results:

--- a/examples/example_16/ulens_model_fit.py
+++ b/examples/example_16/ulens_model_fit.py
@@ -334,7 +334,8 @@ class UlensModelFit(object):
         """
         Check if MulensModel is new enough
         """
-        print('\nMulensModel version:', mm.__version__, end='\n\n')
+        code_versions = f"{mm.__version__} and {__version__}"
+        print('\nMulensModel and script versions:', code_versions, end='\n\n')
         if int(mm.__version__.split('.')[0]) < 2:
             raise RuntimeError(
                 "ulens_model_fit.py requires MulensModel in version "
@@ -2311,6 +2312,11 @@ class UlensModelFit(object):
 
         This version works with EMCEE version 2.X and 3.0.
         """
+        lst = [mm.__version__, __version__]
+        code_version = f"MulensModel and example versions: {lst}"
+        if self._yaml_results:
+            print(code_version, **self._yaml_kwargs)
+
         accept_rate = np.mean(self._sampler.acceptance_fraction)
         out = "Mean acceptance fraction: {0:.3f}".format(accept_rate)
         print(out)

--- a/examples/example_16/ulens_model_fit.py
+++ b/examples/example_16/ulens_model_fit.py
@@ -11,8 +11,8 @@ import math
 import numpy as np
 from scipy.interpolate import interp1d
 from matplotlib import pyplot as plt
-from matplotlib import gridspec, rc, rcParams, rcParamsDefault
-from matplotlib.backends.backend_pdf import PdfPages
+from matplotlib import gridspec, rcParams, rcParamsDefault
+# from matplotlib.backends.backend_pdf import PdfPages
 
 import_failed = set()
 try:
@@ -2364,7 +2364,7 @@ class UlensModelFit(object):
         self._print_best_model()
         if self._yaml_results:
             self._print_yaml_best_model()
-        
+
         if self._shift_t_0 and self._yaml_results:
             print("Plots shift_t_0 : {:}".format(self._shift_t_0_val),
                   **self._yaml_kwargs)
@@ -3101,7 +3101,7 @@ class UlensModelFit(object):
         color = settings.get("color", "red")
         label = settings.get("label", "magnification")
         labels = settings.get("labels")
-        
+
         ylim = plt.ylim()
         ax2 = plt.gca().twinx()
         (A_min, A_max, sb_fluxes) = self._second_Y_axis_get_fluxes(ylim)
@@ -3115,7 +3115,7 @@ class UlensModelFit(object):
         if out1 or out2:
             ax2.get_yaxis().set_visible(False)
             return
-        
+
         ticks = mm.Utils.get_mag_from_flux(flux)
         ax2.set_ylabel(label).set_color(color)
         ax2.spines['right'].set_color(color)
@@ -3134,7 +3134,7 @@ class UlensModelFit(object):
             total_source_flux = sum(source_flux)
         A_min = (flux_min - blend_flux) / total_source_flux
         A_max = (flux_max - blend_flux) / total_source_flux
-        
+
         return A_min, A_max, (total_source_flux, blend_flux)
 
     def _second_Y_axis_optimal(self, ax2, A_min, A_max):
@@ -3144,23 +3144,23 @@ class UlensModelFit(object):
         A_values = A_values[(A_values >= 1.) & (A_values < A_max)]
         is_integer = [mag.is_integer() for mag in A_values]
         if all(is_integer):
-            labels = [f"%d" % int(x) for x in A_values]
+            labels = ["%d" % int(x) for x in A_values]
             return A_values.tolist(), labels, False
 
         fnum = np.array([str(x)[::-1].find(".") for x in A_values])
         labels = np.array([f"%0.{max(fnum)}f" % x for x in A_values])
         if max(fnum) > 3 and len(fnum[fnum <= 3]) < 3:
             msg = ("The computed magnifications for the second Y scale cover"
-                    " a range too small to be shown: {:}")
+                   " a range too small to be shown: {:}")
             warnings.warn(msg.format(A_values))
             return A_values.tolist(), labels.tolist(), True
         if max(fnum) > 3:
-            labels = np.array([f"%0.3f" % x for x in A_values])
+            labels = np.array(["%0.3f" % x for x in A_values])
 
         return A_values[fnum <= 3].tolist(), labels[fnum <= 3].tolist(), False
 
     def _second_Y_axis_warnings(self, flux, labels, A_values, A_min, A_max):
-        
+
         if np.any(flux < 0.):
             mask = (flux > 0.)
             flux = flux[mask]
@@ -3169,7 +3169,7 @@ class UlensModelFit(object):
                    "because they correspond to negative flux which cannot "
                    "be translated to magnitudes.")
             warnings.warn(msg.format(np.sum(np.logical_not(mask))))
-        
+
         if (np.min(A_values) < A_min or np.max(A_values) > A_max or
                 np.any(flux < 0.)):
             msg = ("Provided magnifications for the second (i.e., right-hand "

--- a/examples/example_16/ulens_model_fit.py
+++ b/examples/example_16/ulens_model_fit.py
@@ -2356,6 +2356,10 @@ class UlensModelFit(object):
         if self._yaml_results:
             self._print_yaml_best_model()
 
+        if self._shift_t_0 and self._yaml_results:
+            print("Plots shift_t_0 : {:}".format(self._shift_t_0_value),
+                  **self._yaml_kwargs)
+
     def _extract_posterior_samples_EMCEE(self):
         """
         set self._samples_flat and self._samples for EMCEE
@@ -2500,6 +2504,7 @@ class UlensModelFit(object):
                 index = self._fit_parameters.index(name)
                 values = self._samples_flat[:, index]
                 mean = np.mean(values)
+                self._shift_t_0_value = int(mean)
                 try:
                     self._samples_flat[:, index] -= int(mean)
                     if 'trace' in self._plots:


### PR DESCRIPTION
It contains all the improvements to example 16 listed in issue #93.

As a complement, the value `optimal` is now allowed in "plots" -> "best model" -> "second Y scale" -> "magnifications", in order to calculate optimal values of magnification instead of giving values that can be out of range. If `optimal` is provided, `labels` can not be given for this axis.