### PR TITLE
Remove build wheels for Python 3.7

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
         # Skips PyPy
         os: [ubuntu-latest, macos-latest]
         cibw_archs: [auto64]
-        cibw_build: [cp37-*, cp38-*, cp39-*, cp310-*, cp311-*]
+        cibw_build: [cp38-*, cp39-*, cp310-*, cp311-*]
         cibw_skip: [pp*]
         include:
         # MacOS Silicon (Python >= 3.8)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -86,11 +86,9 @@ jobs:
         name: wheelhouse
         path: dist/
 
-    - run: "ls -a dist/"
-
-    # - name: Publish package to PyPI
-    #   # All files in dist/ are published
-    #   uses: pypa/gh-action-pypi-publish@release/v1
-    #   with:
-    #     user: __token__
-    #     password: ${{ secrets.PYPI_API_TOKEN }}
+    - name: Publish package to PyPI
+      # All files in dist/ are published
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ on:
         type: boolean
 
 env:
-  PUBLISH: ${{ inputs.publish || true }} # Default true for automatic runs
+  PUBLISH: ${{ inputs.publish == '' && true || inputs.publish }} # Default true for automatic runs
 
 jobs:
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,15 +28,12 @@ jobs:
         # A matrix of OSs, Python verisons, and architectures
         # Skips PyPy
         os: [ubuntu-latest, macos-latest]
-        cibw_archs: [auto64]
+        cibw_archs: [auto64, arm64]
         cibw_build: [cp38-*, cp39-*, cp310-*, cp311-*]
         cibw_skip: [pp*]
-        include:
-        # MacOS Silicon (Python >= 3.8)
-        - {os: macos-latest, cibw_archs: "arm64", cw_build: "cp38-*"}
-        - {os: macos-latest, cibw_archs: "arm64", cw_build: "cp39-*"}
-        - {os: macos-latest, cibw_archs: "arm64", cw_build: "cp310-*"}
-        - {os: macos-latest, cibw_archs: "arm64", cw_build: "cp311-*"}
+        exclude:
+        - os: ubuntu-latest
+          cibw_archs: "arm64"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,9 +15,9 @@ jobs:
       matrix:
         # A matrix of OSs, Python verisons, and architectures
         # Skips PyPy
-        os: ubuntu-latest # [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest] # [ubuntu-latest, macos-latest]
         cibw_archs: [auto64]
-        cibw_build: cp37-* # [cp37-*, cp38-*, cp39-*, cp310-*, cp311-*]
+        cibw_build: [cp37-*] # [cp37-*, cp38-*, cp39-*, cp310-*, cp311-*]
         cibw_skip: [pp*]
         # include:
         # MacOS Silicon (Python >= 3.8)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,8 +9,8 @@ on:
     inputs:
       publish:
         description: |
-          Should publish to PyPA (default false for manual runs). Artifacts will
-          still be made available in both cases.
+          Should publish to PyPA (default false for manual runs). Artifacts are
+          available in both cases.
         default: false
         type: boolean
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -86,9 +86,11 @@ jobs:
         name: wheelhouse
         path: dist/
 
-    - name: Publish package to PyPI
-      # All files in dist/ are published
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
+    - run: "ls -a dist/"
+
+    # - name: Publish package to PyPI
+    #   # All files in dist/ are published
+    #   uses: pypa/gh-action-pypi-publish@release/v1
+    #   with:
+    #     user: __token__
+    #     password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,16 +15,16 @@ jobs:
       matrix:
         # A matrix of OSs, Python verisons, and architectures
         # Skips PyPy
-        os: [ubuntu-latest, macos-latest]
+        os: ubuntu-latest # [ubuntu-latest, macos-latest]
         cibw_archs: [auto64]
-        cibw_build: [cp37-*, cp38-*, cp39-*, cp310-*, cp311-*]
+        cibw_build: cp37-* # [cp37-*, cp38-*, cp39-*, cp310-*, cp311-*]
         cibw_skip: [pp*]
-        include:
+        # include:
         # MacOS Silicon (Python >= 3.8)
-        - {os: macos-latest, cibw_archs: "arm64", cw_build: "cp38-*"}
-        - {os: macos-latest, cibw_archs: "arm64", cw_build: "cp39-*"}
-        - {os: macos-latest, cibw_archs: "arm64", cw_build: "cp310-*"}
-        - {os: macos-latest, cibw_archs: "arm64", cw_build: "cp311-*"}
+        # - {os: macos-latest, cibw_archs: "arm64", cw_build: "cp38-*"}
+        # - {os: macos-latest, cibw_archs: "arm64", cw_build: "cp39-*"}
+        # - {os: macos-latest, cibw_archs: "arm64", cw_build: "cp310-*"}
+        # - {os: macos-latest, cibw_archs: "arm64", cw_build: "cp311-*"}
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,7 @@ jobs:
         - {os: macos-latest, cibw_archs: "arm64", cw_build: "cp311-*"}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.17
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python
       uses: actions/setup-python@v4
@@ -82,7 +82,7 @@ jobs:
     needs: [build_source, build_wheels]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Download sdist artifacts to dist/
       uses: actions/download-artifact@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,16 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      publish:
+        description: |
+          Should publish to PyPA (default false for manual runs). Artifacts will
+          still be made available in both cases.
+        default: false
+        type: boolean
+
+env:
+  PUBLISH: ${{ inputs.publish || true }} # Default true for automatic runs
 
 jobs:
   build_wheels:
@@ -15,22 +25,22 @@ jobs:
       matrix:
         # A matrix of OSs, Python verisons, and architectures
         # Skips PyPy
-        os: [ubuntu-latest] # [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest]
         cibw_archs: [auto64]
-        cibw_build: [cp37-*] # [cp37-*, cp38-*, cp39-*, cp310-*, cp311-*]
+        cibw_build: [cp37-*, cp38-*, cp39-*, cp310-*, cp311-*]
         cibw_skip: [pp*]
-        # include:
+        include:
         # MacOS Silicon (Python >= 3.8)
-        # - {os: macos-latest, cibw_archs: "arm64", cw_build: "cp38-*"}
-        # - {os: macos-latest, cibw_archs: "arm64", cw_build: "cp39-*"}
-        # - {os: macos-latest, cibw_archs: "arm64", cw_build: "cp310-*"}
-        # - {os: macos-latest, cibw_archs: "arm64", cw_build: "cp311-*"}
+        - {os: macos-latest, cibw_archs: "arm64", cw_build: "cp38-*"}
+        - {os: macos-latest, cibw_archs: "arm64", cw_build: "cp39-*"}
+        - {os: macos-latest, cibw_archs: "arm64", cw_build: "cp310-*"}
+        - {os: macos-latest, cibw_archs: "arm64", cw_build: "cp311-*"}
 
     steps:
       - uses: actions/checkout@v3
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.11.2
+        uses: pypa/cibuildwheel@v2.17
         env:
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
           CIBW_BUILD: ${{ matrix.cibw_build }}
@@ -87,6 +97,7 @@ jobs:
         path: dist/
 
     - name: Publish package to PyPI
+      if: ${{ env.PUBLISH }}
       # All files in dist/ are published
       uses: pypa/gh-action-pypi-publish@release/v1
       with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,10 +18,12 @@ env:
   PUBLISH: ${{ inputs.publish || true }} # Default true for automatic runs
 
 jobs:
+
   build_wheels:
     name: ${{ matrix.os }} ${{ matrix.cibw_archs }} ${{ matrix.cibw_build }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false # If false, continue with other matrix even if one fails
       matrix:
         # A matrix of OSs, Python verisons, and architectures
         # Skips PyPy


### PR DESCRIPTION
## Changes
- Remove build wheels for Python 3.7
- Bump actions/checkout to v4
- Simplify matrix (still builds amd64 for Linux and MacOS, arm64 for MacOS, and for Python 3.8--3.11)
- Disables fail fast, now all wheels attempt to build. 
- Add option to not upload to PyPI when _publish_ workflow is triggered manually

---

For disable fail fast, in the future even if some wheels fail, you may want to upload to PyPImanually the wheels that did succeed. I believe it is possible to add more wheels in an uploaded version of PyPI.