### PR TITLE
Fix manual publish option to skip publish to PyPA

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -74,6 +74,7 @@ jobs:
 
   publish:
     name: Publish to PyPI
+    if:  ${{ !(inputs.disable-publish || false) }} # Only skips if inputs.disable-publish is true
     runs-on: ubuntu-latest
     needs: [build_source, build_wheels]
 
@@ -93,7 +94,6 @@ jobs:
         path: dist/
 
     - name: Publish package to PyPI
-      if:  ${{ !(inputs.disable-publish || false) }} # Only skips if inputs.disable-publish is true
       # All files in dist/ are published
       uses: pypa/gh-action-pypi-publish@release/v1
       with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,15 +7,12 @@ on:
     types: [published]
   workflow_dispatch:
     inputs:
-      publish:
+      disable-publish:
         description: |
-          Should publish to PyPA (default false for manual runs). Artifacts are
+          Disables publish to PyPA (default, true for manual runs). Artifacts are
           available in both cases.
-        default: false
+        default: true
         type: boolean
-
-env:
-  PUBLISH: ${{ inputs.publish == '' && true || inputs.publish }} # Default true for automatic runs
 
 jobs:
 
@@ -96,7 +93,7 @@ jobs:
         path: dist/
 
     - name: Publish package to PyPI
-      if: ${{ env.PUBLISH }}
+      if: ! ${{ inputs.disable-publish || false }} # Only skips if inputs.disable-publish is true
       # All files in dist/ are published
       uses: pypa/gh-action-pypi-publish@release/v1
       with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -93,7 +93,7 @@ jobs:
         path: dist/
 
     - name: Publish package to PyPI
-      if: ! ${{ inputs.disable-publish || false }} # Only skips if inputs.disable-publish is true
+      if:  ${{ !(inputs.disable-publish || false) }} # Only skips if inputs.disable-publish is true
       # All files in dist/ are published
       uses: pypa/gh-action-pypi-publish@release/v1
       with:


### PR DESCRIPTION
Broken, because the if condition I had didn't work as intended. Now you can toggle on to disable and off to enable publish to PyPA.

See example, the publish stage should be skipped (not failure)
https://github.com/ketozhang/MulensModel/actions/runs/8871760998