### PR TITLE
Allowed q > 1 and added unit tests to check magnification

### DIFF
--- a/source/MulensModel/__init__.py
+++ b/source/MulensModel/__init__.py
@@ -26,7 +26,15 @@ from MulensModel.utils import MAG_ZEROPOINT, Utils
 
 from .version import __version__
 
-__all__ = ['mulensobjects', 'MODULE_PATH', 'DATA_PATH', 'BinaryLens']
+__all__ = ['mulensobjects', 'MODULE_PATH', 'DATA_PATH', 'BinaryLens',
+           'BinaryLensWithShear', 'Caustics', 'CausticsPointWithShear',
+           'CausticsWithShear', 'Coordinates', 'Event', 'FitData', 'Horizons',
+           'LimbDarkeningCoeffs', 'MagnificationCurve', 'Model',
+           'ModelParameters', 'which_parameters', 'MulensData', 'Lens',
+           'Source', 'MulensSystem', 'orbits', 'PointLens',
+           'get_pspl_magnification', 'PointLensWithShear',
+           'PointLensFiniteSource', 'SatelliteSkyCoord', 'Trajectory',
+           'UniformCausticSampling', 'MAG_ZEROPOINT',  'Utils', '__version__']
 
 MODULE_PATH = path.abspath(__file__)
 for i in range(3):

--- a/source/MulensModel/modelparameters.py
+++ b/source/MulensModel/modelparameters.py
@@ -878,7 +878,7 @@ class ModelParameters(object):
 
         for name in ['q']:
             if name in parameters.keys():
-                if parameters[name] <= 0. or parameters[name] >= 1.:
+                if parameters[name] <= 0.:
                     msg = "Parameter {:} has to be in (0, 1) range, not {:}"
                     raise ValueError(msg.format(name, parameters[name]))
 
@@ -1234,7 +1234,7 @@ class ModelParameters(object):
 
     @q.setter
     def q(self, new_q):
-        if new_q < 0. or new_q > 1.:
+        if new_q < 0.:
             raise ValueError('mass ratio q has to be between 0 and 1')
         self.parameters['q'] = new_q
         self._update_sources('q', new_q)

--- a/source/MulensModel/tests/test_ModelParameters.py
+++ b/source/MulensModel/tests/test_ModelParameters.py
@@ -150,6 +150,38 @@ def test_positive_t_E():
     assert params.t_E == params.t_eff / abs(params.u_0)
 
 
+def test_q_gt_1_is_good():
+    """
+    Check if the magnification is reproduced by transforming q -> 1/q and
+    alpha -> alpha +/- 180, including for q > 1. See issue #84.
+    """
+    t_0 = 3583.
+    u_0 = 0.3
+    t_E = 12.
+    s = 1.65
+    q = 0.25
+    alpha = 339.0
+    rho = 0.001
+
+    planet = mm.Model({'t_0': t_0, 'u_0': u_0, 't_E': t_E, 's': s, 'q': q,
+                       'alpha': alpha, 'rho': rho})
+    planet_2 = mm.Model({'t_0': t_0, 'u_0': u_0, 't_E': t_E, 's': s, 'q': 1/q,
+                         'alpha': alpha+180., 'rho': rho})
+    planet_3 = mm.Model({'t_0': t_0, 'u_0': u_0, 't_E': t_E, 's': s, 'q': 1/q,
+                         'alpha': alpha-180., 'rho': rho})
+    list_of_methods = [3588., 'VBBL', 3594., 'hexadecapole', 3598.0]
+    planet.set_magnification_methods(list_of_methods)
+    planet_2.set_magnification_methods(list_of_methods)
+    planet_3.set_magnification_methods(list_of_methods)
+    t_range = np.arange(3580., 3600., 0.1)
+    magnifications_1 = planet.get_magnification(time=t_range)
+    magnifications_2 = planet_2.get_magnification(time=t_range)
+    magnifications_3 = planet_3.get_magnification(time=t_range)
+
+    assert max(magnifications_1 - magnifications_2) < 1e-10
+    assert max(magnifications_1 - magnifications_3) < 1e-10
+
+
 def test_rho_t_e_t_star():
     """check if conversions between rho, t_E, and t_star work ok"""
     t_0 = 2450000.

--- a/source/MulensModel/tests/test_ModelParameters.py
+++ b/source/MulensModel/tests/test_ModelParameters.py
@@ -182,6 +182,31 @@ def test_q_gt_1_is_good():
     assert max(magnifications_1 - magnifications_3) < 1e-10
 
 
+def test_q_gt_1_is_smooth():
+    """
+    Check that there is a smooth transition from q = 0.99 and q = 1.01.
+    """
+    t_0 = 3583.
+    u_0 = 0.3
+    t_E = 12.
+    s = 2.18
+    q = 0.99  # 0.999 also works fine
+    alpha = 339.0
+    rho = 0.001
+    planet = mm.Model({'t_0': t_0, 'u_0': u_0, 't_E': t_E, 's': s, 'q': q,
+                       'alpha': alpha, 'rho': rho})
+    planet_2 = mm.Model({'t_0': t_0, 'u_0': u_0, 't_E': t_E, 's': s, 'q': 1/q,
+                        'alpha': alpha+180., 'rho': rho})
+
+    planet.set_magnification_methods([3590., 'VBBL', 3595.])
+    planet_2.set_magnification_methods([3590., 'VBBL', 3595.])
+    t_range = np.arange(3580., 3600., 0.1)
+    magnifications_1 = planet.get_magnification(time=t_range)
+    magnifications_2 = planet_2.get_magnification(time=t_range)
+
+    assert max(magnifications_1 - magnifications_2) < 1e-10
+
+
 def test_rho_t_e_t_star():
     """check if conversions between rho, t_E, and t_star work ok"""
     t_0 = 2450000.

--- a/source/MulensModel/tests/test_ModelParameters.py
+++ b/source/MulensModel/tests/test_ModelParameters.py
@@ -30,7 +30,7 @@ class TestModelParameters(unittest.TestCase):
                                 'shear_G': 0.1, 'alpha': 123.})
         with self.assertRaises(ValueError):
             mm.ModelParameters({'t_0': 123., 'u_0': 1, 't_E': 10., 's': 1.2,
-                               'alpha': 34.56, 'q': 1.5})
+                               'alpha': 34.56, 'q': -0.5})
 
     def test_init_for_2_sources(self):
         """


### PR DESCRIPTION
Removing two conditions of `q <= 1` from `modelparameters.py`, one unit test was changed and two unit tests were added to ensure that the magnification is reproduced by the transformations `q -> 1/q` and `alpha -> alpha +/- 180`.

Parameters from [example01](https://github.com/rpoleski/MulensModel/blob/master/examples/example_01_models.py) were used to test different mass ratios, except for the separation `s`, which was changed to reproduce a similar caustic crossing for binary lens.

See issue #84 for more details. Comments are welcome!