### PR TITLE
Fix warnings in Version3_1 unit tests

### DIFF
--- a/source/MulensModel/binarylens.py
+++ b/source/MulensModel/binarylens.py
@@ -98,7 +98,6 @@ class BinaryLensPointSourceMagnification(PointSourcePointLensMagnification):
             if isinstance(self.trajectory.x, np.ndarray):
                 self._source_x = float(self.trajectory.x[0])
             else:
-                print("RAPHAEL: type(self.trajectory.x)", type(self.trajectory.x))
                 self._source_x = float(self.trajectory.x)
 
         return self._source_x
@@ -116,7 +115,10 @@ class BinaryLensPointSourceMagnification(PointSourcePointLensMagnification):
         magnification calculation.
         """
         if self._source_y is None:
-            self._source_y = float(self.trajectory.y[0])
+            if isinstance(self.trajectory.x, np.ndarray):
+                self._source_y = float(self.trajectory.y[0])
+            else:
+                self._source_y = float(self.trajectory.y)
 
         return self._source_y
 
@@ -361,7 +363,6 @@ class BinaryLensPointSourceWM95Magnification(BinaryLensPointSourceMagnification)
             if isinstance(self.trajectory.x, np.ndarray):
                 self._source_x = float(self.trajectory.x[0] + x_shift)
             else:
-                print("RAPHAEL: type(self.trajectory.x)", type(self.trajectory.x))
                 self._source_x = float(self.trajectory.x + x_shift)
 
         return self._source_x
@@ -824,10 +825,9 @@ class BinaryLensAdaptiveContouringMagnification(BinaryLensHexadecapoleMagnificat
         # so we have to transform the coordinates below.
         if self._source_x is None:
             if isinstance(self.trajectory.x, np.ndarray):
-                self._source_x = float(self.trajectory.x[0])
+                self._source_x = float(-self.trajectory.x[0])
             else:
-                print("RAPHAEL: type(self.trajectory.x)", type(self.trajectory.x))
-                self._source_x = float(self.trajectory.x)
+                self._source_x = float(-self.trajectory.x)
 
         return self._source_x
 
@@ -841,6 +841,9 @@ class BinaryLensAdaptiveContouringMagnification(BinaryLensHexadecapoleMagnificat
         # AdaptiveContouring uses different coordinates conventions,
         # so we have to transform the coordinates below.
         if self._source_y is None:
-            self._source_y = float(-self.trajectory.y[0])
+            if isinstance(self.trajectory.y, np.ndarray):
+                self._source_y = float(-self.trajectory.y[0])
+            else:
+                self._source_y = float(-self.trajectory.y)
 
         return self._source_y

--- a/source/MulensModel/binarylens.py
+++ b/source/MulensModel/binarylens.py
@@ -95,7 +95,11 @@ class BinaryLensPointSourceMagnification(PointSourcePointLensMagnification):
         if self._source_x is None:
             print('traj.x', self.trajectory.x)
             print('type', type(self.trajectory.x))
-            self._source_x = float(self.trajectory.x)
+            if isinstance(self.trajectory.x, np.ndarray):
+                self._source_x = float(self.trajectory.x[0])
+            else:
+                print("RAPHAEL: type(self.trajectory.x)", type(self.trajectory.x))
+                self._source_x = float(self.trajectory.x)
 
         return self._source_x
 
@@ -112,7 +116,7 @@ class BinaryLensPointSourceMagnification(PointSourcePointLensMagnification):
         magnification calculation.
         """
         if self._source_y is None:
-            self._source_y = float(self.trajectory.y)
+            self._source_y = float(self.trajectory.y[0])
 
         return self._source_y
 
@@ -354,7 +358,11 @@ class BinaryLensPointSourceWM95Magnification(BinaryLensPointSourceMagnification)
             print('traj.x', self.trajectory.x)
             print('type(traj.x)', type(self.trajectory.x))
             print('x_shift', x_shift)
-            self._source_x = float(self.trajectory.x + x_shift)
+            if isinstance(self.trajectory.x, np.ndarray):
+                self._source_x = float(self.trajectory.x[0] + x_shift)
+            else:
+                print("RAPHAEL: type(self.trajectory.x)", type(self.trajectory.x))
+                self._source_x = float(self.trajectory.x + x_shift)
 
         return self._source_x
 
@@ -815,7 +823,11 @@ class BinaryLensAdaptiveContouringMagnification(BinaryLensHexadecapoleMagnificat
         # AdaptiveContouring uses different coordinates conventions,
         # so we have to transform the coordinates below.
         if self._source_x is None:
-            self._source_x = float(-self.trajectory.x)
+            if isinstance(self.trajectory.x, np.ndarray):
+                self._source_x = float(self.trajectory.x[0])
+            else:
+                print("RAPHAEL: type(self.trajectory.x)", type(self.trajectory.x))
+                self._source_x = float(self.trajectory.x)
 
         return self._source_x
 
@@ -829,6 +841,6 @@ class BinaryLensAdaptiveContouringMagnification(BinaryLensHexadecapoleMagnificat
         # AdaptiveContouring uses different coordinates conventions,
         # so we have to transform the coordinates below.
         if self._source_y is None:
-            self._source_y = float(-self.trajectory.y)
+            self._source_y = float(-self.trajectory.y[0])
 
         return self._source_y

--- a/source/MulensModel/binarylenswithshear.py
+++ b/source/MulensModel/binarylenswithshear.py
@@ -606,6 +606,6 @@ class BinaryLensPointSourceWithShearVBBLMagnification(BinaryLensPointSourceWithS
     @property
     def source_x(self):
         if self._source_x is None:
-            self._source_x = float(self.trajectory.x)
+            self._source_x = float(self.trajectory.x[0])
 
         return self._source_x

--- a/source/MulensModel/elliputils.py
+++ b/source/MulensModel/elliputils.py
@@ -1,6 +1,7 @@
 import os.path
 import numpy as np
 from scipy.interpolate import interp1d, interp2d
+from scipy.interpolate import RegularGridInterpolator as RGI
 
 import MulensModel as mm
 
@@ -42,7 +43,11 @@ class EllipUtils(object):
                 if line[:3] == "# Y":
                     yy = np.array([float(t) for t in line.split()[2:]])
         pp = np.loadtxt(self.file_3)
-        EllipUtils._interpolate_3 = interp2d(xx, yy, pp.T, kind='cubic')
+        try:
+            EllipUtils._interpolate_3 = RGI((xx, yy), pp, method='cubic',
+                                            bounds_error=False)
+        except ValueError:
+            EllipUtils._interpolate_3 = interp2d(xx, yy, pp.T, kind='cubic')
         EllipUtils._interpolate_3_min_x = np.min(xx)
         EllipUtils._interpolate_3_max_x = np.max(xx)
         EllipUtils._interpolate_3_min_y = np.min(yy)


### PR DESCRIPTION
I applied two recent changes from `master` branch to the `Version3_1` branch, in order to solve warnings in the unit tests. The first change is related to interp2d replacing by RGI (issue #74, PR #113) and the second is about NumPy deprecation warnings related to converting length-1 arrays into floats (issue #127, PR #130).

Previously, there were 89 warnings and now there are only 9. The missing warnings seems to have been inserted on purpose, so I kept them.

The following two tests were failing with TypeError:
```
FAILED source/MulensModel/tests/test_Model.py::TestBLPS02AC::test_mag_calculation_1 - TypeError: only length-1 arrays can be converted to Python scalars
FAILED source/MulensModel/tests/test_Model.py::TestBLPS02AC::test_mag_calculation_2 - TypeError: only length-1 arrays can be converted to Python scalars
```
and now only the first one is failing with AssertionError:
`FAILED tests/test_Model.py::TestBLPS02AC::test_mag_calculation_1 - AssertionError: `