### PR TITLE
UltraNest fitting method added to example_16

### DIFF
--- a/examples/example_16/ob03235_2_full.yaml
+++ b/examples/example_16/ob03235_2_full.yaml
@@ -105,10 +105,10 @@ fitting_parameters:
     # basename: out_ob08092_O4_MN-
     # multimodal: True
     # evidence tolerance: 0.5
-    ## UltraNest only (log directory, derived param names, show_status,
+    ## UltraNest only (log directory, derived parameter names, show_status,
     ## dlogz=0.5, frac_remain=0.01, max_num_improvement_loops=-1)
     # log directory: ultranest_outputs/
-    # derived param names: flux_s_1 flux_b_1
+    # derived parameter names: flux_s_1 flux_b_1
     # show_status: True
     # dlogz: 2.
     # frac_remain: 0.5

--- a/examples/example_16/ob03235_2_full.yaml
+++ b/examples/example_16/ob03235_2_full.yaml
@@ -7,11 +7,12 @@ photometry_files:
 #    - {..., add_2450000: False}
 fit_method: EMCEE
 # Options: EMCEE, MultiNest, UltraNest.
-# If not given, EMCEE is used if starting_parameters are given; if prior_limits
-# are given, MultiNest or UltraNest is used depending on fitting_parameters.
-# If MultiNest/UltraNest is selected: starting_parameters, fit_constraints,
-# min_values and max_value cannot be provided. The trace plot cannot be
-# generated as well.
+# If fit_method is not given, EMCEE is used if starting_parameters are given;
+# and MultiNest or UltraNest is used if prior_limits are given, depending on
+# the combination of fitting_parameters.
+# If MultiNest/UltraNest is used, this file cannot have starting_parameters,
+# fit_constraints (except negative_blending_flux_sigma_mag and prior->t_E for
+# UltraNest), min_values, max_values and plots->trace.
 model:
     methods: 2452800. point_source 2452833. VBBL 2452845. point_source 2452860.
     default method: point_source_point_lens
@@ -108,7 +109,7 @@ fitting_parameters:
     ## UltraNest only (log directory, derived parameter names, show_status,
     ## dlogz=0.5, frac_remain=0.01, max_num_improvement_loops=-1)
     # log directory: ultranest_outputs/
-    # derived parameter names: flux_s_1 flux_b_1
+    # derived parameter names: flux_s_1 flux_b_1 flux_s_2 flux_b_2
     # show_status: True
     # dlogz: 2.
     # frac_remain: 0.5

--- a/examples/example_16/ob03235_2_full.yaml
+++ b/examples/example_16/ob03235_2_full.yaml
@@ -90,12 +90,12 @@ fitting_parameters:
     progress: True
     posterior file: ob03235_2_models.npy
     posterior file fluxes: all
-    ## MultiNest only (basename, multimodal, evidence tolerance)
+    ## MultiNest only (basename, multimodal, evidence tolerance=0.5)
     # basename: out_ob08092_O4_MN-
     # multimodal: True
-    # # evidence tolerance: 0.5
+    # evidence tolerance: 0.5
     ## UltraNest only (log directory, derived parameter names, show_status,
-    ## dlogz, frac_remain, max_num_improvement_loops)
+    ## dlogz=0.5, frac_remain=0.01, max_num_improvement_loops=-1)
     # log directory: ultranest_outputs/
     # derived parameter names: source_flux blending_flux
     # show_status: True

--- a/examples/example_16/ob03235_2_full.yaml
+++ b/examples/example_16/ob03235_2_full.yaml
@@ -43,6 +43,17 @@ starting_parameters:
     #   file: ob08092-o4_starting_file_input.txt
     #   parameters: t_0 u_0 t_E
     # See also ob08092-o4_starting_file.yaml
+# prior_limits:
+#     t_0: [2452847.5, 2452848.5]
+#     u_0: [0.08, 0.18]
+#     t_E: 58.7 64.7
+#     rho: [0.0004, 0.0018]
+#     pi_E_N: [-0.05, 0.05]
+#     pi_E_E: [-0.05, 0.05]
+#     s: [1.077, 1.125]
+#     q: [0.001, 0.02]
+#     alpha: [219.4, 229.4]
+#     # Only MultiNest and UltraNest, cannot be given with starting_parameters
 fit_constraints:
     negative_blending_flux_sigma_mag: 20.  
     #one can specify for which dataset soft constrain on blending flux should be applied: sigma dataset_label(s)
@@ -94,10 +105,10 @@ fitting_parameters:
     # basename: out_ob08092_O4_MN-
     # multimodal: True
     # evidence tolerance: 0.5
-    ## UltraNest only (log directory, derived parameter names, show_status,
+    ## UltraNest only (log directory, derived param names, show_status,
     ## dlogz=0.5, frac_remain=0.01, max_num_improvement_loops=-1)
     # log directory: ultranest_outputs/
-    # derived parameter names: source_flux blending_flux
+    # derived param names: flux_s_1 flux_b_1
     # show_status: True
     # dlogz: 2.
     # frac_remain: 0.5

--- a/examples/example_16/ob03235_2_full.yaml
+++ b/examples/example_16/ob03235_2_full.yaml
@@ -7,8 +7,8 @@ photometry_files:
 #    - {..., add_2450000: False}
 fit_method: EMCEE
 # Options: EMCEE, MultiNest, UltraNest.
-# If not given, EMCEE is used if starting_parameters are given or MultiNest
-# if prior_limits are given.
+# If not given, EMCEE is used if starting_parameters are given; if prior_limits
+# are given, MultiNest or UltraNest is used depending on fitting_parameters.
 # If MultiNest/UltraNest is selected: starting_parameters, fit_constraints,
 # min_values and max_value cannot be provided. The trace plot cannot be
 # generated as well.

--- a/examples/example_16/ob03235_2_full.yaml
+++ b/examples/example_16/ob03235_2_full.yaml
@@ -5,6 +5,8 @@ photometry_files:
 #    - {file_name: some_K2_data.txt, phot_fmt: flux, bandpass: 'Kp', ephemerides_file: K2_ephemeris_01.dat}
 # For files with time starting with 245...:
 #    - {..., add_2450000: False}
+fit_method: EMCEE
+# Method options: EMCEE (default), MultiNest, UltraNest
 model:
     methods: 2452800. point_source 2452833. VBBL 2452845. point_source 2452860.
     default method: point_source_point_lens

--- a/examples/example_16/ob03235_2_full.yaml
+++ b/examples/example_16/ob03235_2_full.yaml
@@ -6,7 +6,12 @@ photometry_files:
 # For files with time starting with 245...:
 #    - {..., add_2450000: False}
 fit_method: EMCEE
-# Method options: EMCEE (default), MultiNest, UltraNest
+# Options: EMCEE, MultiNest, UltraNest.
+# If not given, EMCEE is used if starting_parameters are given or MultiNest
+# if prior_limits are given.
+# If MultiNest/UltraNest is selected: starting_parameters, fit_constraints,
+# min_values and max_value cannot be provided. The trace plot cannot be
+# generated as well.
 model:
     methods: 2452800. point_source 2452833. VBBL 2452845. point_source 2452860.
     default method: point_source_point_lens
@@ -78,12 +83,27 @@ max_values:
     s: 2.
     alpha: 360.
 fitting_parameters:
+    ## EMCEE only
     n_walkers: 20
     n_steps: 4
     n_burn:  2
     progress: True
     posterior file: ob03235_2_models.npy
     posterior file fluxes: all
+    ## MultiNest only (basename, multimodal, evidence tolerance)
+    # basename: out_ob08092_O4_MN-
+    # multimodal: True
+    # # evidence tolerance: 0.5
+    ## UltraNest only (log directory, derived parameter names, show_status,
+    ## dlogz, frac_remain, max_num_improvement_loops)
+    # log directory: ultranest_outputs/
+    # derived parameter names: source_flux blending_flux
+    # show_status: True
+    # dlogz: 2.
+    # frac_remain: 0.5
+    # max_num_improvement_loops: 0
+    ## Both for MultiNest and UltraNest (number of live points)
+    # n_live_points: 20
 plots:
     best model:
         # You can skip the line below - the light curve will be plotted on screen.

--- a/examples/example_16/ob08092-o4_MN.yaml
+++ b/examples/example_16/ob08092-o4_MN.yaml
@@ -1,29 +1,21 @@
 photometry_files:
     data/OB08092/phot_ob08092_O4.dat
-fit_method: UltraNest  # options: EMCEE, MultiNest, UltraNest (... dynesty)
+fit_method: MultiNest
 prior_limits:
     t_0: [2455379.4, 2455379.76]
     u_0: [0.3, 0.65]
     t_E: 16. 19.6
 fitting_parameters:
-    # MultiNest only (basename, multimodal, evidence tolerance)
     basename: out_ob08092_O4_MN-
     multimodal: True
+    # Default settings of other parameters:
     # evidence tolerance: 0.5
-    # UltraNest only (log directory, derived parameter names, show_status)
-    log directory: ultranest_outputs/
-    derived parameter names: source_flux blending_flux
-    show_status: True
-    # `n_live_points` can be used in MultiNest and UltraNest
     n_live_points: 1000
 plots:
     best model:
         file: out_ob08092_O4_MN_model.png
-        second Y scale:
-            magnifications: optimal
     triangle:
         file: out_ob08092_O4_MN_triangle.png
-        shift t_0: False
 other_output:
     yaml output:
-        file name: ob03235_2_all_results_UN.yaml
+        file name: ob08092_O4_MN_all_results.yaml

--- a/examples/example_16/ob08092-o4_MN.yaml
+++ b/examples/example_16/ob08092-o4_MN.yaml
@@ -6,11 +6,16 @@ prior_limits:
     u_0: [0.3, 0.65]
     t_E: 16. 19.6
 fitting_parameters:
+    # MultiNest only (basename, multimodal, evidence tolerance)
     basename: out_ob08092_O4_MN-
     multimodal: True
+    # evidence tolerance: 0.5
+    # UltraNest only (log directory, derived parameter names, show_status)
+    log directory: ultranest_outputs/
+    # derived parameter names: source_flux blending_flux
+    show_status: True
+    # `n_live_points` can be used in MultiNest and UltraNest
     n_live_points: 1000
-# Default settings of other parameters:
-#    evidence tolerance: 0.5
 plots:
     best model:
         file: out_ob08092_O4_MN_model.png

--- a/examples/example_16/ob08092-o4_MN.yaml
+++ b/examples/example_16/ob08092-o4_MN.yaml
@@ -19,5 +19,11 @@ fitting_parameters:
 plots:
     best model:
         file: out_ob08092_O4_MN_model.png
+        second Y scale:
+            magnifications: optimal
     triangle:
         file: out_ob08092_O4_MN_triangle.png
+        shift t_0: False
+other_output:
+    yaml output:
+        file name: ob03235_2_all_results_UN.yaml

--- a/examples/example_16/ob08092-o4_MN.yaml
+++ b/examples/example_16/ob08092-o4_MN.yaml
@@ -12,7 +12,7 @@ fitting_parameters:
     # evidence tolerance: 0.5
     # UltraNest only (log directory, derived parameter names, show_status)
     log directory: ultranest_outputs/
-    # derived parameter names: source_flux blending_flux
+    derived parameter names: source_flux blending_flux
     show_status: True
     # `n_live_points` can be used in MultiNest and UltraNest
     n_live_points: 1000

--- a/examples/example_16/ob08092-o4_MN.yaml
+++ b/examples/example_16/ob08092-o4_MN.yaml
@@ -1,5 +1,6 @@
 photometry_files:
     data/OB08092/phot_ob08092_O4.dat
+fit_method: UltraNest  # options: EMCEE, MultiNest, UltraNest (... dynesty)
 prior_limits:
     t_0: [2455379.4, 2455379.76]
     u_0: [0.3, 0.65]

--- a/examples/example_16/ob08092-o4_UN.yaml
+++ b/examples/example_16/ob08092-o4_UN.yaml
@@ -10,6 +10,14 @@ fitting_parameters:
     derived parameter names: source_flux blending_flux
     show_status: True
     n_live_points: 1000
+    # `n_live_points` can also be named `min_num_live_points`
+    # If it is smaller than 40, `cluster_num_live_points` is also reduced.
+    # UltraNest may increase n_live_points if it is too low to achieve the
+    # logz accuracy (default=0.5). It can be avoided increasing dlogz:
+    dlogz: 2.
+    # The parameters below can reduce runtime (default is -1 and 0.01)
+    # frac_remain: 0.5
+    # max_num_improvement_loops: 0
 plots:
     best model:
         file: out_ob08092_O4_UN_model.png

--- a/examples/example_16/ob08092-o4_UN.yaml
+++ b/examples/example_16/ob08092-o4_UN.yaml
@@ -7,7 +7,7 @@ prior_limits:
     t_E: 16. 19.6
 fitting_parameters:
     log directory: ultranest_outputs/
-    derived param names: flux_s_1 flux_b_1
+    derived parameter names: flux_s_1 flux_b_1
     show_status: True
     n_live_points: 1000
     # `n_live_points` can also be named `min_num_live_points`

--- a/examples/example_16/ob08092-o4_UN.yaml
+++ b/examples/example_16/ob08092-o4_UN.yaml
@@ -10,7 +10,7 @@ fit_constraints:
     prior:
         t_E: Mroz et al. 2020
 fitting_parameters:
-    log directory: ultranest_outputs/
+    log directory: outputs_ultranest/
     derived parameter names: flux_s_1 flux_b_1
     show_status: True
     n_live_points: 1000

--- a/examples/example_16/ob08092-o4_UN.yaml
+++ b/examples/example_16/ob08092-o4_UN.yaml
@@ -15,7 +15,7 @@ fitting_parameters:
     # UltraNest may increase n_live_points if it is too low to achieve the
     # logz accuracy (default=0.5). It can be avoided increasing dlogz:
     dlogz: 2.
-    # The parameters below can reduce runtime (default is -1 and 0.01)
+    # The parameters below can reduce runtime (default is 0.01 and -1)
     # frac_remain: 0.5
     # max_num_improvement_loops: 0
 plots:

--- a/examples/example_16/ob08092-o4_UN.yaml
+++ b/examples/example_16/ob08092-o4_UN.yaml
@@ -1,0 +1,23 @@
+photometry_files:
+    data/OB08092/phot_ob08092_O4.dat
+fit_method: UltraNest
+prior_limits:
+    t_0: [2455379.4, 2455379.76]
+    u_0: [0.3, 0.65]
+    t_E: 16. 19.6
+fitting_parameters:
+    log directory: ultranest_outputs/
+    derived parameter names: source_flux blending_flux
+    show_status: True
+    n_live_points: 1000
+plots:
+    best model:
+        file: out_ob08092_O4_UN_model.png
+        second Y scale:
+            magnifications: optimal
+    triangle:
+        file: out_ob08092_O4_UN_triangle.png
+        shift t_0: False
+other_output:
+    yaml output:
+        file name: ob08092_O4_UN_all_results.yaml

--- a/examples/example_16/ob08092-o4_UN.yaml
+++ b/examples/example_16/ob08092-o4_UN.yaml
@@ -7,7 +7,7 @@ prior_limits:
     t_E: 16. 19.6
 fitting_parameters:
     log directory: ultranest_outputs/
-    derived parameter names: source_flux blending_flux
+    derived param names: flux_s_1 flux_b_1
     show_status: True
     n_live_points: 1000
     # `n_live_points` can also be named `min_num_live_points`

--- a/examples/example_16/ob08092-o4_UN.yaml
+++ b/examples/example_16/ob08092-o4_UN.yaml
@@ -5,6 +5,10 @@ prior_limits:
     t_0: [2455379.4, 2455379.76]
     u_0: [0.3, 0.65]
     t_E: 16. 19.6
+fit_constraints:
+    negative_blending_flux_sigma_mag: 20.
+    prior:
+        t_E: Mroz et al. 2020
 fitting_parameters:
     log directory: ultranest_outputs/
     derived parameter names: flux_s_1 flux_b_1

--- a/examples/example_16/ob08092-o4_minimal_MN.yaml
+++ b/examples/example_16/ob08092-o4_minimal_MN.yaml
@@ -1,6 +1,7 @@
 photometry_files:
     data/OB08092/phot_ob08092_O4.dat
-fit_method: UltraNest  # options: EMCEE, MultiNest, UltraNest (... dynesty)
+fit_method: MultiNest
+# fit_method options if prior_limits are given: MultiNest and UltraNest
 prior_limits:
     t_0: [2455379.4, 2455379.76]
     u_0: [0.46, 0.65]

--- a/examples/example_16/ob08092-o4_minimal_MN.yaml
+++ b/examples/example_16/ob08092-o4_minimal_MN.yaml
@@ -1,5 +1,6 @@
 photometry_files:
     data/OB08092/phot_ob08092_O4.dat
+fit_method: UltraNest  # options: EMCEE, MultiNest, UltraNest (... dynesty)
 prior_limits:
     t_0: [2455379.4, 2455379.76]
     u_0: [0.46, 0.65]

--- a/examples/example_16/ulens_model_fit.py
+++ b/examples/example_16/ulens_model_fit.py
@@ -2558,7 +2558,10 @@ class UlensModelFit(object):
 
     def _setup_fit_UltraNest(self):
         """
-        Prepare UltraNest fit, declaring sampler instance
+        Prepare UltraNest fit, declaring sampler instance.
+        If the names of the derived parameters are not given, the source
+        and blending fluxes are assigned, with the former containing _1
+        and _2 in case of multiple sources.
         """
         if self._return_fluxes and len(self._derived_params_UltraNest) == 0:
             self._derived_params_UltraNest = ["source_flux", "blending_flux"]
@@ -2650,7 +2653,7 @@ class UlensModelFit(object):
         n_params = n_dims + self._n_fluxes_per_dataset * self._return_fluxes
         cube_out = self._min_values + cube[:n_dims] * self._range_values
 
-        # Check with Radek: are "x_caustic_in" lines needed here?
+        # Check: are "x_caustic_in" lines needed as in line 2597?
 
         if self._return_fluxes:
             fluxes = self._get_fluxes()
@@ -3247,9 +3250,9 @@ class UlensModelFit(object):
         Parse results of UltraNest fitting.
         Functions that print and save EMCEE results are also called here.
         """
-        # re-weighted posterior samples
+        # re-weighted posterior samples:
         # self._samples_flat = self._result_UltraNest['samples'][:, :-2]
-        # weighted samples from the posterior
+        # weighted samples from the posterior:
         weighted_samples = self._result_UltraNest['weighted_samples']
         index = self._n_fit_parameters
         self._samples_flat = weighted_samples['points'][:, :index]

--- a/examples/example_16/ulens_model_fit.py
+++ b/examples/example_16/ulens_model_fit.py
@@ -1372,11 +1372,9 @@ class UlensModelFit(object):
         if 'n_walkers' in self._fitting_parameters:
             self._n_walkers = self._fitting_parameters['n_walkers']
         else:
-            if self._starting_parameters_type == 'file':
-                self._n_walkers = None
-            elif self._starting_parameters_type == 'draw':
+            if self._starting_parameters_type == 'draw':
                 self._n_walkers = 4 * self._n_fit_parameters
-            else:
+            elif self._starting_parameters_type != 'file':
                 raise ValueError(
                     'Unexpected: ' + self._starting_parameters_type)
 

--- a/examples/example_16/ulens_model_fit.py
+++ b/examples/example_16/ulens_model_fit.py
@@ -43,7 +43,7 @@ try:
 except Exception:
     raise ImportError('\nYou have to install MulensModel first!\n')
 
-__version__ = '0.38.0'
+__version__ = '0.39.0'
 
 
 class UlensModelFit(object):

--- a/examples/example_16/ulens_model_fit.py
+++ b/examples/example_16/ulens_model_fit.py
@@ -2629,7 +2629,7 @@ class UlensModelFit(object):
         https://johannesbuchner.github.io/UltraNest/example-sine-line.html
         """
         n_dims = self._n_fit_parameters
-        n_params = n_dims + self._n_fluxes * self._return_fluxes
+        n_params = n_dims + self._n_fluxes_per_dataset * self._return_fluxes
         cube_out = self._min_values + cube[:n_dims] * self._range_values
 
         # Check with Radek: are "x_caustic_in" lines needed here?

--- a/examples/example_16/ulens_model_fit.py
+++ b/examples/example_16/ulens_model_fit.py
@@ -1800,6 +1800,7 @@ class UlensModelFit(object):
         Parse constraints on what is done with posterior.
         """
         if 'posterior parsing' not in self._fit_constraints:
+            self._parse_posterior_abs = list()
             return
 
         if self._fit_method != "EMCEE":

--- a/examples/example_16/ulens_model_fit.py
+++ b/examples/example_16/ulens_model_fit.py
@@ -234,7 +234,7 @@ class UlensModelFit(object):
             there is a check if directory exists. If not given, no outputs
             are saved.
 
-            ``derived param names`` (*str*) - names of additional derived
+            ``derived parameters names`` (*str*) - names of additional derived
             parameters created by transform. In microlensing, they are usually
             the source(s) and blending fluxes. If not given, they are ignored
             in the transform function.
@@ -578,7 +578,7 @@ class UlensModelFit(object):
         if all([key in args_MultiNest for key in self._fitting_parameters]):
             return "MultiNest"
 
-        args_UltraNest = ['log directory', 'derived param names',
+        args_UltraNest = ['log directory', 'derived parameters names',
                           'show_status', 'dlogz', 'frac_remain',
                           'max_num_improvement_loops', 'n_live_points']
         if all([key in args_UltraNest for key in self._fitting_parameters]):
@@ -1481,7 +1481,7 @@ class UlensModelFit(object):
         ints = ['min_num_live_points', 'max_num_improvement_loops']
         if 'n_live_points' in settings:
             ints[0] = 'n_live_points'
-        strings = ['log directory', 'derived param names']
+        strings = ['log directory', 'derived parameters names']
         floats = ['dlogz', 'frac_remain']
         allowed = strings + bools + ints + floats
 
@@ -1495,7 +1495,7 @@ class UlensModelFit(object):
             elif not path.isdir(self._log_dir_UltraNest):
                 raise ValueError("log directory value in fitting_parameters"
                                  "exists, but it is a file.")
-        value = settings.pop("derived param names", "")
+        value = settings.pop("derived parameters names", "")
         self._derived_param_names_UltraNest = value.split()
 
         keys = {"n_live_points": "min_num_live_points"}


### PR DESCRIPTION
Implementation of the UltraNest fitting method to example_16, using several functions similar to MultiNest.
There are no required parameters to run, but some optional parameters that may be useful in some cases were added.

Commented lines were added to `ob03235_2_full.yaml` file, but a YAML file specific for the application of UltraNest to the same data is also included. Comments are welcome!

My impression is that the algorithm was not very effective in finding the solution if a large parameter space is given, specially for cases with more parameters or complex magnifications, e.g. binary lens.