### PR TITLE
Removed astropy units of times and alpha in Version3_1

### DIFF
--- a/source/MulensModel/modelparameters.py
+++ b/source/MulensModel/modelparameters.py
@@ -668,8 +668,8 @@ class ModelParameters(object):
             full_name += " ({:})".format(form['unit'])
 
         value = getattr(self, key)
-        if isinstance(value, u.Quantity):
-            value = value.value
+        # if isinstance(value, u.Quantity):
+        #     value = value.value
 
         return (full_name, value)
 
@@ -978,9 +978,9 @@ class ModelParameters(object):
         self._check_valid_parameter_values(parameters)
         self.parameters = dict(parameters)
 
-        for parameter in ['t_E', 't_star', 't_eff', 't_star_1', 't_star_2']:
-            if parameter in self.parameters:
-                self._set_time_quantity(parameter, self.parameters[parameter])
+        # for parameter in ['t_E', 't_star', 't_eff', 't_star_1', 't_star_2']:
+        #     if parameter in self.parameters:
+        #         self._set_time_quantity(parameter, self.parameters[parameter])
 
         angle_parameters = [
             'alpha', 'xi_Omega_node', 'xi_inclination',
@@ -1027,10 +1027,11 @@ class ModelParameters(object):
         Save a variable with units of time (e.g. t_E, t_star,
         t_eff). If units are not given, assume days.
         """
-        if isinstance(new_time, u.Quantity):
-            self.parameters[key] = new_time
-        else:
-            self.parameters[key] = new_time * u.day
+        # if isinstance(new_time, u.Quantity):
+        #     self.parameters[key] = new_time
+        # else:
+        #     self.parameters[key] = new_time * u.day
+        self.parameters[key] = new_time
 
     def _check_time_quantity(self, key):
         """
@@ -1107,7 +1108,7 @@ class ModelParameters(object):
             try:
                 u_0_quantity = (
                     self.parameters['t_eff'] / self.parameters['t_E'])
-                return (u_0_quantity + 0.).value
+                return (u_0_quantity + 0.)  # .value
                 # Adding 0 ensures the units are simplified.
             except KeyError:
                 raise AttributeError(
@@ -1136,14 +1137,15 @@ class ModelParameters(object):
         *astropy.Quantity*, but always returns *float* in units of days.
         """
         if 't_star' in self.parameters.keys():
-            self._check_time_quantity('t_star')
-            return self.parameters['t_star'].to(u.day).value
+            # self._check_time_quantity('t_star')
+            return self.parameters['t_star']  # .to(u.day).value
         elif ('rho' in self.parameters.keys() and self._type['Cassan08']):
             return self.rho * self.t_E
         else:
             try:
-                return (self.parameters['t_E'].to(u.day).value *
-                        self.parameters['rho'])
+                # return (self.parameters['t_E'].to(u.day).value *
+                #         self.parameters['rho'])
+                return (self.parameters['t_E'] * self.parameters['rho'])
             except KeyError:
                 raise AttributeError(
                     't_star is not defined for these parameters: {0}'.format(
@@ -1152,7 +1154,8 @@ class ModelParameters(object):
     @t_star.setter
     def t_star(self, new_t_star):
         if 't_star' in self.parameters.keys():
-            self._set_time_quantity('t_star', new_t_star)
+            # self._set_time_quantity('t_star', new_t_star)
+            self.parameters['t_star'] = new_t_star
             self._update_sources('t_star', new_t_star)
         else:
             raise KeyError('t_star is not a parameter of this model.')
@@ -1172,12 +1175,13 @@ class ModelParameters(object):
         *astropy.Quantity*, but always returns *float* in units of days.
         """
         if 't_eff' in self.parameters.keys():
-            self._check_time_quantity('t_eff')
-            return self.parameters['t_eff'].to(u.day).value
+            # self._check_time_quantity('t_eff')
+            return self.parameters['t_eff']  # .to(u.day).value
         else:
             try:
-                return (self.parameters['t_E'].to(u.day).value *
-                        self.parameters['u_0'])
+                # return (self.parameters['t_E'].to(u.day).value *
+                #         self.parameters['u_0'])
+                return (self.parameters['t_E'] * self.parameters['u_0'])
             except KeyError:
                 raise AttributeError(
                     't_eff is not defined for these parameters: {0}'.format(
@@ -1186,7 +1190,8 @@ class ModelParameters(object):
     @t_eff.setter
     def t_eff(self, new_t_eff):
         if 't_eff' in self.parameters.keys():
-            self._set_time_quantity('t_eff', new_t_eff)
+            # self._set_time_quantity('t_eff', new_t_eff)
+            self.parameters['t_eff'] = new_t_eff
             self._update_sources('t_eff', new_t_eff)
         else:
             raise KeyError('t_eff is not a parameter of this model.')
@@ -1204,8 +1209,8 @@ class ModelParameters(object):
             self._get_standard_parameters_from_Cassan08()
             return self._standard_parameters['t_E']
         if 't_E' in self.parameters.keys():
-            self._check_time_quantity('t_E')
-            return self.parameters['t_E'].to(u.day).value
+            # self._check_time_quantity('t_E')
+            return self.parameters['t_E']  # .to(u.day).value
         elif ('t_star' in self.parameters.keys() and
               'rho' in self.parameters.keys()):
             return self.t_star / self.rho
@@ -1228,7 +1233,8 @@ class ModelParameters(object):
             raise ValueError('Einstein timescale cannot be negative:', new_t_E)
 
         if 't_E' in self.parameters.keys():
-            self._set_time_quantity('t_E', new_t_E)
+            # self._set_time_quantity('t_E', new_t_E)
+            self.parameters['t_E'] = new_t_E
             self._update_sources('t_E', new_t_E)
         else:
             raise KeyError('t_E is not a parameter of this model.')
@@ -1922,13 +1928,13 @@ class ModelParameters(object):
         *astropy.Quantity*, but always returns *float* in units of days.
         """
         if 't_star_1' in self.parameters.keys():
-            self._check_time_quantity('t_star_1')
-            return self.parameters['t_star_1'].to(u.day).value
+            # self._check_time_quantity('t_star_1')
+            return self.parameters['t_star_1']  # .to(u.day).value
         else:
             try:
-                t_E = self._source_1_parameters.parameters['t_E'].to(u.day)
+                t_E = self._source_1_parameters.parameters['t_E']  # .to(u.day)
                 rho = self._source_1_parameters.parameters['rho']
-                return t_E.value * rho
+                return t_E * rho  # .value * rho
             except KeyError:
                 raise AttributeError(
                     't_star_1 is not defined for these parameters: {0}'.format(
@@ -1937,7 +1943,8 @@ class ModelParameters(object):
     @t_star_1.setter
     def t_star_1(self, new_t_star_1):
         if 't_star_1' in self.parameters.keys():
-            self._set_time_quantity('t_star_1', new_t_star_1)
+            # self._set_time_quantity('t_star_1', new_t_star_1)
+            self.parameters['t_star_1'] = new_t_star_1
             self._source_1_parameters.t_star = new_t_star_1
         else:
             raise KeyError('t_star_1 is not a parameter of this model.')
@@ -1957,13 +1964,13 @@ class ModelParameters(object):
         *astropy.Quantity*, but always returns *float* in units of days.
         """
         if 't_star_2' in self.parameters.keys():
-            self._check_time_quantity('t_star_2')
-            return self.parameters['t_star_2'].to(u.day).value
+            # self._check_time_quantity('t_star_2')
+            return self.parameters['t_star_2']  # .to(u.day).value
         else:
             try:
-                t_E = self._source_2_parameters.parameters['t_E'].to(u.day)
+                t_E = self._source_2_parameters.parameters['t_E']  # .to(u.day)
                 rho = self._source_2_parameters.parameters['rho']
-                return t_E.value * rho
+                return t_E * rho  # .value * rho
             except KeyError:
                 raise AttributeError(
                     't_star_2 is not defined for these parameters: {0}'.format(
@@ -1972,7 +1979,8 @@ class ModelParameters(object):
     @t_star_2.setter
     def t_star_2(self, new_t_star_2):
         if 't_star_2' in self.parameters.keys():
-            self._set_time_quantity('t_star_2', new_t_star_2)
+            # self._set_time_quantity('t_star_2', new_t_star_2)
+            self.parameters['t_star_2'] = new_t_star_2
             self._source_2_parameters.t_star = new_t_star_2
         else:
             raise KeyError('t_star_2 is not a parameter of this model.')

--- a/source/MulensModel/modelparameters.py
+++ b/source/MulensModel/modelparameters.py
@@ -1,4 +1,3 @@
-from astropy import units as u
 import numpy as np
 import warnings
 
@@ -941,8 +940,7 @@ class ModelParameters(object):
         for (key, value) in parameters.items():
             if key == 'pi_E':
                 continue
-            check = (not np.isscalar(value) or isinstance(value, str))
-            if not isinstance(value, u.Quantity) and check:
+            if not np.isscalar(value) or isinstance(value, str):
                 msg = "{:} must be a scalar: {:}, {:}"
                 raise TypeError(msg.format(key, value, type(value)))
 
@@ -1254,11 +1252,6 @@ class ModelParameters(object):
                              'Cassan (2008) parameterization')
 
         self.parameters['alpha'] = new_alpha
-# XXX only float input
-#        if isinstance(new_alpha, u.Quantity):
-#            self.parameters['alpha'] = new_alpha
-#        else:
-#            self.parameters['alpha'] = new_alpha * u.deg
         self._warn_if_angle_outside_reasonable_range(
             self.parameters['alpha'], 'alpha')
         self._update_sources('alpha', new_alpha)
@@ -1269,8 +1262,6 @@ class ModelParameters(object):
         """
         min_ = -360.
         max_ = 540.
-        if isinstance(value, u.Quantity):
-            value = value.to(u.deg).value
         if value < min_ or value > max_:
             fmt = "Strange value of angle {:}: {:}"
             warnings.warn(fmt.format(name, value), RuntimeWarning)

--- a/source/MulensModel/modelparameters.py
+++ b/source/MulensModel/modelparameters.py
@@ -668,9 +668,6 @@ class ModelParameters(object):
             full_name += " ({:})".format(form['unit'])
 
         value = getattr(self, key)
-        # if isinstance(value, u.Quantity):
-        #     value = value.value
-
         return (full_name, value)
 
     def _get_formats_for_repr(self, form, full_name):
@@ -978,10 +975,6 @@ class ModelParameters(object):
         self._check_valid_parameter_values(parameters)
         self.parameters = dict(parameters)
 
-        # for parameter in ['t_E', 't_star', 't_eff', 't_star_1', 't_star_2']:
-        #     if parameter in self.parameters:
-        #         self._set_time_quantity(parameter, self.parameters[parameter])
-
         angle_parameters = [
             'alpha', 'xi_Omega_node', 'xi_inclination',
             'xi_argument_of_latitude_reference', 'xi_omega_periapsis']
@@ -1021,24 +1014,6 @@ class ModelParameters(object):
                 setattr(self._source_2_parameters, parameter, value)
 
             self._update_sources_xallarap_reference()
-
-    def _set_time_quantity(self, key, new_time):
-        """
-        Save a variable with units of time (e.g. t_E, t_star,
-        t_eff). If units are not given, assume days.
-        """
-        # if isinstance(new_time, u.Quantity):
-        #     self.parameters[key] = new_time
-        # else:
-        #     self.parameters[key] = new_time * u.day
-        self.parameters[key] = new_time
-
-    def _check_time_quantity(self, key):
-        """
-        Make sure that value for give key has quantity, add it if missing.
-        """
-        if not isinstance(self.parameters[key], u.Quantity):
-            self._set_time_quantity(key, self.parameters[key])
 
     def _get_uniform_caustic_sampling(self):
         """
@@ -1108,8 +1083,7 @@ class ModelParameters(object):
             try:
                 u_0_quantity = (
                     self.parameters['t_eff'] / self.parameters['t_E'])
-                return (u_0_quantity + 0.)  # .value
-                # Adding 0 ensures the units are simplified.
+                return u_0_quantity
             except KeyError:
                 raise AttributeError(
                     'u_0 is not defined for these parameters: {0}'.format(
@@ -1137,14 +1111,11 @@ class ModelParameters(object):
         *astropy.Quantity*, but always returns *float* in units of days.
         """
         if 't_star' in self.parameters.keys():
-            # self._check_time_quantity('t_star')
-            return self.parameters['t_star']  # .to(u.day).value
+            return self.parameters['t_star']
         elif ('rho' in self.parameters.keys() and self._type['Cassan08']):
             return self.rho * self.t_E
         else:
             try:
-                # return (self.parameters['t_E'].to(u.day).value *
-                #         self.parameters['rho'])
                 return (self.parameters['t_E'] * self.parameters['rho'])
             except KeyError:
                 raise AttributeError(
@@ -1154,7 +1125,6 @@ class ModelParameters(object):
     @t_star.setter
     def t_star(self, new_t_star):
         if 't_star' in self.parameters.keys():
-            # self._set_time_quantity('t_star', new_t_star)
             self.parameters['t_star'] = new_t_star
             self._update_sources('t_star', new_t_star)
         else:
@@ -1175,12 +1145,9 @@ class ModelParameters(object):
         *astropy.Quantity*, but always returns *float* in units of days.
         """
         if 't_eff' in self.parameters.keys():
-            # self._check_time_quantity('t_eff')
-            return self.parameters['t_eff']  # .to(u.day).value
+            return self.parameters['t_eff']
         else:
             try:
-                # return (self.parameters['t_E'].to(u.day).value *
-                #         self.parameters['u_0'])
                 return (self.parameters['t_E'] * self.parameters['u_0'])
             except KeyError:
                 raise AttributeError(
@@ -1190,7 +1157,6 @@ class ModelParameters(object):
     @t_eff.setter
     def t_eff(self, new_t_eff):
         if 't_eff' in self.parameters.keys():
-            # self._set_time_quantity('t_eff', new_t_eff)
             self.parameters['t_eff'] = new_t_eff
             self._update_sources('t_eff', new_t_eff)
         else:
@@ -1209,8 +1175,7 @@ class ModelParameters(object):
             self._get_standard_parameters_from_Cassan08()
             return self._standard_parameters['t_E']
         if 't_E' in self.parameters.keys():
-            # self._check_time_quantity('t_E')
-            return self.parameters['t_E']  # .to(u.day).value
+            return self.parameters['t_E']
         elif ('t_star' in self.parameters.keys() and
               'rho' in self.parameters.keys()):
             return self.t_star / self.rho
@@ -1233,7 +1198,6 @@ class ModelParameters(object):
             raise ValueError('Einstein timescale cannot be negative:', new_t_E)
 
         if 't_E' in self.parameters.keys():
-            # self._set_time_quantity('t_E', new_t_E)
             self.parameters['t_E'] = new_t_E
             self._update_sources('t_E', new_t_E)
         else:
@@ -1291,7 +1255,7 @@ class ModelParameters(object):
 
         self.parameters['alpha'] = new_alpha
 # XXX only float input
-#        if isinstance(new_alpha, u.Quantity): 
+#        if isinstance(new_alpha, u.Quantity):
 #            self.parameters['alpha'] = new_alpha
 #        else:
 #            self.parameters['alpha'] = new_alpha * u.deg
@@ -1620,7 +1584,7 @@ class ModelParameters(object):
         """
         *float*
 
-        Change rate of angle :py:attr:`~alpha` in deg/year. 
+        Change rate of angle :py:attr:`~alpha` in deg/year.
         """
         return self.parameters['dalpha_dt']
 
@@ -1928,13 +1892,12 @@ class ModelParameters(object):
         *astropy.Quantity*, but always returns *float* in units of days.
         """
         if 't_star_1' in self.parameters.keys():
-            # self._check_time_quantity('t_star_1')
-            return self.parameters['t_star_1']  # .to(u.day).value
+            return self.parameters['t_star_1']
         else:
             try:
-                t_E = self._source_1_parameters.parameters['t_E']  # .to(u.day)
+                t_E = self._source_1_parameters.parameters['t_E']
                 rho = self._source_1_parameters.parameters['rho']
-                return t_E * rho  # .value * rho
+                return t_E * rho
             except KeyError:
                 raise AttributeError(
                     't_star_1 is not defined for these parameters: {0}'.format(
@@ -1943,7 +1906,6 @@ class ModelParameters(object):
     @t_star_1.setter
     def t_star_1(self, new_t_star_1):
         if 't_star_1' in self.parameters.keys():
-            # self._set_time_quantity('t_star_1', new_t_star_1)
             self.parameters['t_star_1'] = new_t_star_1
             self._source_1_parameters.t_star = new_t_star_1
         else:
@@ -1964,13 +1926,12 @@ class ModelParameters(object):
         *astropy.Quantity*, but always returns *float* in units of days.
         """
         if 't_star_2' in self.parameters.keys():
-            # self._check_time_quantity('t_star_2')
-            return self.parameters['t_star_2']  # .to(u.day).value
+            return self.parameters['t_star_2']
         else:
             try:
-                t_E = self._source_2_parameters.parameters['t_E']  # .to(u.day)
+                t_E = self._source_2_parameters.parameters['t_E']
                 rho = self._source_2_parameters.parameters['rho']
-                return t_E * rho  # .value * rho
+                return t_E * rho
             except KeyError:
                 raise AttributeError(
                     't_star_2 is not defined for these parameters: {0}'.format(
@@ -1979,7 +1940,6 @@ class ModelParameters(object):
     @t_star_2.setter
     def t_star_2(self, new_t_star_2):
         if 't_star_2' in self.parameters.keys():
-            # self._set_time_quantity('t_star_2', new_t_star_2)
             self.parameters['t_star_2'] = new_t_star_2
             self._source_2_parameters.t_star = new_t_star_2
         else:
@@ -2006,9 +1966,9 @@ class ModelParameters(object):
             print('fails')
             print(self.parameters.keys())
             raise AttributeError('rho_1 is not defined for these parameters')
-            #raise AttributeError(
-            #    'rho_1 is not defined for these parameters') #: {0}'.format(
-                 #self.parameters.keys()))
+            # raise AttributeError(
+            #     'rho_1 is not defined for these parameters') #: {0}'.format(
+            #     self.parameters.keys()))
 
     @rho_1.setter
     def rho_1(self, new_rho_1):

--- a/source/MulensModel/mulensobjects/mulenssystem.py
+++ b/source/MulensModel/mulensobjects/mulenssystem.py
@@ -113,16 +113,15 @@ class MulensSystem(object):
         """
         try:
             t_E = self.theta_E/self.mu_rel
-            return t_E.to(u.day)
+            t_E_value = t_E.to(u.day).value
+            return t_E_value
         except Exception:
             return None
 
     @t_E.setter
     def t_E(self, t_E):
-        if isinstance(t_E, u.Quantity):
-            self.mu_rel = self.theta_E / t_E.to(u.year)
-        else:
-            self.mu_rel = self.theta_E / t_E * u.year
+        t_E_unit = t_E * u.day
+        self.mu_rel = self.theta_E / t_E_unit.to(u.yr)
 
     @property
     def pi_rel(self):

--- a/source/MulensModel/tests/test_Event.py
+++ b/source/MulensModel/tests/test_Event.py
@@ -172,7 +172,7 @@ def test_event_get_chi2_4():
     data = mm.MulensData(file_name=SAMPLE_FILE_01)
 
     ev = mm.Event()
-    params = {'t_0': t_0, 'u_0': u_0, 't_E': t_E * u.day}
+    params = {'t_0': t_0, 'u_0': u_0, 't_E': t_E}
     mod = mm.Model(params)
     ev.model = mod
     ev.datasets = [data]
@@ -181,7 +181,7 @@ def test_event_get_chi2_4():
 
     ev.model.parameters.parameters['t_0'] += 1.
     ev.model.parameters.parameters['u_0'] += 0.1
-    ev.model.parameters.parameters['t_E'] += 1. * u.day
+    ev.model.parameters.parameters['t_E'] += 1.
     chi2_2 = ev.get_chi2()
 
     assert chi2_2 > chi2_1

--- a/source/MulensModel/tests/test_ModelParameters.py
+++ b/source/MulensModel/tests/test_ModelParameters.py
@@ -55,12 +55,12 @@ def test_init_parameters():
     """
     t_0 = 6141.593
     u_0 = 0.5425
-    t_E = 62.63*u.day
+    t_E = 62.63  # *u.day
     params = mm.ModelParameters({'t_0': t_0, 'u_0': u_0, 't_E': t_E})
 
     np.testing.assert_almost_equal(params.t_0, t_0)
     np.testing.assert_almost_equal(params.u_0, u_0)
-    np.testing.assert_almost_equal(params.t_E, t_E.value)
+    np.testing.assert_almost_equal(params.t_E, t_E)  # .value)
 
 
 def test_repr_parameters():
@@ -69,7 +69,7 @@ def test_repr_parameters():
     """
     t_0 = 2456141.593
     u_0 = 0.5425
-    t_E = 62.63*u.day
+    t_E = 62.63  # *u.day
     params = mm.ModelParameters({'t_0': t_0, 'u_0': u_0, 't_E': t_E})
 
     out_1 = "    t_0 (HJD)       u_0    t_E (d) \n"
@@ -280,7 +280,7 @@ def test_rho_t_e_t_star():
     t_0 = 2450000.
     u_0 = 0.1
     t_E_1 = 20.
-    t_E_2 = t_E_1 * u.day
+    t_E_2 = t_E_1  # * u.day
     rho = 0.001
     t_star_1 = t_E_1 * rho
     t_star_2 = t_E_2 * rho
@@ -303,7 +303,7 @@ class test(unittest.TestCase):
     def test_too_much_rho_t_e_t_star(self):
         t_0 = 2450000.
         u_0 = 0.1
-        t_E = 20. * u.day
+        t_E = 20.  # * u.day
         rho = 0.001
         t_star = t_E * rho
         with self.assertRaises(KeyError):
@@ -318,7 +318,7 @@ def test_update():
     """
     t_0 = 2456141.593
     u_0 = 0.5425
-    t_E = 62.63*u.day
+    t_E = 62.63  # *u.day
     params = mm.ModelParameters({'t_0': t_0, 'u_0': u_0, 't_E': t_E})
     params.as_dict().update({'rho': 0.001})
 
@@ -470,7 +470,7 @@ def test_single_lens_convergence_K_shear_G():
     """
     t_0 = 6141.593
     u_0 = 0.5425
-    t_E = 62.63*u.day
+    t_E = 62.63  # *u.day
     convergence_K = 0.1
     shear_G = complex(0.1, 0.2)
     alpha = 200.
@@ -480,7 +480,7 @@ def test_single_lens_convergence_K_shear_G():
 
     np.testing.assert_almost_equal(params.t_0, t_0)
     np.testing.assert_almost_equal(params.u_0, u_0)
-    np.testing.assert_almost_equal(params.t_E, t_E.value)
+    np.testing.assert_almost_equal(params.t_E, t_E)  # .value)
     np.testing.assert_almost_equal(params.convergence_K, convergence_K)
     np.testing.assert_almost_equal(params.shear_G.real, shear_G.real)
 
@@ -846,9 +846,9 @@ def _test_2S1L_xallarap_individual_source_parameters(xi_u):
     parameters = {'q_source': q_source, **parameters_1st}
     model = mm.ModelParameters(parameters)
     check_1st = model.source_1_parameters.as_dict()
-    check_1st['t_E'] = check_1st['t_E'].value
+    check_1st['t_E'] = check_1st['t_E']  # .value
     check_2nd = model.source_2_parameters.as_dict()
-    check_2nd['t_E'] = check_2nd['t_E'].value
+    check_2nd['t_E'] = check_2nd['t_E']  # .value
 
     assert check_1st == parameters_1st
     assert check_2nd == parameters_2nd

--- a/source/MulensModel/tests/test_ModelParameters.py
+++ b/source/MulensModel/tests/test_ModelParameters.py
@@ -3,8 +3,6 @@ import warnings
 import pytest
 import numpy as np
 
-from astropy import units as u
-
 import MulensModel as mm
 
 
@@ -55,12 +53,12 @@ def test_init_parameters():
     """
     t_0 = 6141.593
     u_0 = 0.5425
-    t_E = 62.63  # *u.day
+    t_E = 62.63
     params = mm.ModelParameters({'t_0': t_0, 'u_0': u_0, 't_E': t_E})
 
     np.testing.assert_almost_equal(params.t_0, t_0)
     np.testing.assert_almost_equal(params.u_0, u_0)
-    np.testing.assert_almost_equal(params.t_E, t_E)  # .value)
+    np.testing.assert_almost_equal(params.t_E, t_E)
 
 
 def test_repr_parameters():
@@ -69,7 +67,7 @@ def test_repr_parameters():
     """
     t_0 = 2456141.593
     u_0 = 0.5425
-    t_E = 62.63  # *u.day
+    t_E = 62.63
     params = mm.ModelParameters({'t_0': t_0, 'u_0': u_0, 't_E': t_E})
 
     out_1 = "    t_0 (HJD)       u_0    t_E (d) \n"
@@ -148,8 +146,9 @@ class TestT0X(unittest.TestCase):
         s = 1.0
         q = 0.003
         alpha = 30.
-        self.params = {'t_0': t_0, 'u_0': u_0, 't_E': t_E, 's': s, 'q': q, 'alpha': alpha,
-             'ds_dt': 0.47, 'dalpha_dt': 3.14, 'pi_E_E': 0.1, 'pi_E_N': -0.2}
+        self.params = {'t_0': t_0, 'u_0': u_0, 't_E': t_E, 's': s, 'q': q,
+                       'alpha': alpha, 'ds_dt': 0.47, 'dalpha_dt': 3.14,
+                       'pi_E_E': 0.1, 'pi_E_N': -0.2}
 
     def test_basic(self):
         model_params = mm.ModelParameters(self.params)
@@ -280,7 +279,7 @@ def test_rho_t_e_t_star():
     t_0 = 2450000.
     u_0 = 0.1
     t_E_1 = 20.
-    t_E_2 = t_E_1  # * u.day
+    t_E_2 = t_E_1
     rho = 0.001
     t_star_1 = t_E_1 * rho
     t_star_2 = t_E_2 * rho
@@ -303,7 +302,7 @@ class test(unittest.TestCase):
     def test_too_much_rho_t_e_t_star(self):
         t_0 = 2450000.
         u_0 = 0.1
-        t_E = 20.  # * u.day
+        t_E = 20.
         rho = 0.001
         t_star = t_E * rho
         with self.assertRaises(KeyError):
@@ -318,7 +317,7 @@ def test_update():
     """
     t_0 = 2456141.593
     u_0 = 0.5425
-    t_E = 62.63  # *u.day
+    t_E = 62.63
     params = mm.ModelParameters({'t_0': t_0, 'u_0': u_0, 't_E': t_E})
     params.as_dict().update({'rho': 0.001})
 
@@ -470,7 +469,7 @@ def test_single_lens_convergence_K_shear_G():
     """
     t_0 = 6141.593
     u_0 = 0.5425
-    t_E = 62.63  # *u.day
+    t_E = 62.63
     convergence_K = 0.1
     shear_G = complex(0.1, 0.2)
     alpha = 200.
@@ -480,7 +479,7 @@ def test_single_lens_convergence_K_shear_G():
 
     np.testing.assert_almost_equal(params.t_0, t_0)
     np.testing.assert_almost_equal(params.u_0, u_0)
-    np.testing.assert_almost_equal(params.t_E, t_E)  # .value)
+    np.testing.assert_almost_equal(params.t_E, t_E)
     np.testing.assert_almost_equal(params.convergence_K, convergence_K)
     np.testing.assert_almost_equal(params.shear_G.real, shear_G.real)
 
@@ -591,6 +590,7 @@ tested_keys_1 = ['xi_period', 'xi_semimajor_axis', 'xi_Omega_node',
                  'xi_inclination', 'xi_argument_of_latitude_reference',
                  'xi_eccentricity', 'xi_omega_periapsis']
 tested_keys_2 = tested_keys_1 + ['t_0_xi']
+
 
 @pytest.mark.parametrize("key", tested_keys_2)
 def test_xallarap_set_value_1(key):
@@ -846,9 +846,7 @@ def _test_2S1L_xallarap_individual_source_parameters(xi_u):
     parameters = {'q_source': q_source, **parameters_1st}
     model = mm.ModelParameters(parameters)
     check_1st = model.source_1_parameters.as_dict()
-    check_1st['t_E'] = check_1st['t_E']  # .value
     check_2nd = model.source_2_parameters.as_dict()
-    check_2nd['t_E'] = check_2nd['t_E']  # .value
 
     assert check_1st == parameters_1st
     assert check_2nd == parameters_2nd
@@ -951,7 +949,7 @@ class Test1L3SModels(unittest.TestCase):
         """
         Test that we can access attributes of Triple source models.
         """
-        assert(self.model_params.t_0_3 == self.t_0[2])
+        assert (self.model_params.t_0_3 == self.t_0[2])
         for i in range(3):
             assert (self.model_params.__getattr__(
                 't_0_{0}'.format(i+1)) == self.t_0[i])
@@ -996,7 +994,7 @@ class Test1L3SModels(unittest.TestCase):
         # JCY: don't understand why this test doesn't work, because it does throw an Attribute Error.
         # with np.testing.assert_raises(AttributeError):
         #    print(self.model_params.rho_1)
-            
+
         np.testing.assert_almost_equal(self.model_params.rho_2, self.rho[1])
         np.testing.assert_almost_equal(self.model_params.rho_3, self.rho[2])
 
@@ -1013,7 +1011,7 @@ class Test1L3SModels(unittest.TestCase):
                 'source_{0}_parameters'.format(i+1)).t_star == self.t_star[i])
 
         with np.testing.assert_raises(AttributeError):
-            foo = self.model_params.t_star_1
+            _ = self.model_params.t_star_1
 
         np.testing.assert_almost_equal(self.model_params.t_star_2, self.t_star[1])
         np.testing.assert_almost_equal(self.model_params.t_star_3, self.t_star[2])
@@ -1064,22 +1062,21 @@ class Test1L3SModelErrors(unittest.TestCase):
                       't_0_3': 2, 'u_0_3': 0.3,
                       't_E': 9}
         with self.assertRaises(KeyError):
-            model_params = mm.ModelParameters(parameters)
+            _ = mm.ModelParameters(parameters)
 
         parameters = {'t_0_1': 0, 'u_0_1': 1,
                       't_0_2': 5, 'u_0_2': 0.1, 'rho_2': 0.001,
                       'u_0_3': 0.3,
                       't_E': 9}
         with self.assertRaises(KeyError):
-            model_params = mm.ModelParameters(parameters)
-
+            _ = mm.ModelParameters(parameters)
 
         parameters = {'t_0_1': 0, 'u_0_1': 1,
                       't_0_2': 5, 'u_0_2': 0.1, 'rho_2': 0.001,
                       'rho_3': 0.3,
                       't_E': 9}
         with self.assertRaises(KeyError):
-            model_params = mm.ModelParameters(parameters)
+            _ = mm.ModelParameters(parameters)
 
     def test_bad_1L3S_params(self):
         """
@@ -1091,28 +1088,28 @@ class Test1L3SModelErrors(unittest.TestCase):
                       't_0_3': 2, 'u_0_3': 0.3,
                       't_E': 9}
         with self.assertRaises(KeyError):
-            model_params = mm.ModelParameters(parameters)
+            _ = mm.ModelParameters(parameters)
 
         parameters = {'t_0': 0, 'u_0': 1,
                       't_0_2': 5, 'u_0_2': 0.1, 'rho_2': 0.001,
                       't_0_3': 2, 'u_0_3': 0.3,
                       't_E': 9}
         with self.assertRaises(KeyError):
-            model_params = mm.ModelParameters(parameters)
+            _ = mm.ModelParameters(parameters)
 
         parameters = {'t_0': 0, 'u_0_1': 1,
                       't_0_2': 5, 'u_0_2': 0.1, 'rho': 0.001,
                       't_0_3': 2, 'u_0_3': 0.3,
                       't_E': 9}
         with self.assertRaises(KeyError):
-            model_params = mm.ModelParameters(parameters)
+            _ = mm.ModelParameters(parameters)
 
         parameters = {'t_0': 0, 'u_0_1': 1,
                       't_0_2': 5, 'u_0_2': 0.1, 'rho_2': 0.001,
                       't_0_3': 2, 'u_0_3': 0.3, 't_star': 0.02,
                       't_E': 9}
         with self.assertRaises(KeyError):
-            model_params = mm.ModelParameters(parameters)
+            _ = mm.ModelParameters(parameters)
 
     def test_1L3S_xallarap(self):
         """
@@ -1241,9 +1238,9 @@ class TestParallax3Sources(unittest.TestCase):
         self.pi_E_N = 0.5
         self.pi_E_E = -0.3
         self.static_params = {'t_0_1': 0, 'u_0_1': 1,
-            't_0_2': 5, 'u_0_2': 0.01,
-            't_0_3': 2, 'u_0_3': 0.3,
-            't_E': 9}
+                              't_0_2': 5, 'u_0_2': 0.01,
+                              't_0_3': 2, 'u_0_3': 0.3,
+                              't_E': 9}
         self.parallax_params = {'pi_E_N': self.pi_E_N, 'pi_E_E': self.pi_E_E}
 
         self.dummy_value = 13.
@@ -1277,6 +1274,7 @@ class TestParallax3Sources(unittest.TestCase):
         params = mm.ModelParameters(self.static_params)
         with self.assertRaises(KeyError):
             params.pi_E_E = self.dummy_value
+
 
 class TestSetters2Sources(unittest.TestCase):
 
@@ -1322,15 +1320,15 @@ class TestSetters2Sources(unittest.TestCase):
             {'t_0_1': self.t_0_1, 'u_0_1': self.u_0_1, 't_0_2': self.t_0_2, 't_eff_2': self.t_eff_2, 't_E': self.t_E})
         with self.assertRaises(KeyError):
             params.u_0_2 = self.dummy_value
-            
+
     def test_set_rho_1(self):
         params = mm.ModelParameters(
-            {'t_0_1': self.t_0_1, 'u_0_1': self.u_0_1, 'rho_1': self.rho_1, 
+            {'t_0_1': self.t_0_1, 'u_0_1': self.u_0_1, 'rho_1': self.rho_1,
              't_0_2': self.t_0_2, 'u_0_2': self.u_0_2, 'rho_2': self.rho_2, 't_E': self.t_E})
         params.rho_1 = self.dummy_value
         assert params.rho_1 == self.dummy_value
         assert params._source_1_parameters.rho == self.dummy_value
-        
+
     def test_set_rho_1_error_1(self):
         params = mm.ModelParameters(
             {'t_0_1': self.t_0_1, 'u_0_1': self.u_0_1, 't_0_2': self.t_0_2, 'u_0_2': self.u_0_2, 't_E': self.t_E})
@@ -1346,18 +1344,18 @@ class TestSetters2Sources(unittest.TestCase):
 
     def test_set_rho_2(self):
         params = mm.ModelParameters(
-            {'t_0_1': self.t_0_1, 'u_0_1': self.u_0_1, 'rho_1': self.rho_1, 
+            {'t_0_1': self.t_0_1, 'u_0_1': self.u_0_1, 'rho_1': self.rho_1,
              't_0_2': self.t_0_2, 'u_0_2': self.u_0_2, 'rho_2': self.rho_2, 't_E': self.t_E})
         params.rho_2 = self.dummy_value
         assert params.rho_2 == self.dummy_value
         assert params._source_2_parameters.rho == self.dummy_value
-        
+
     def test_set_rho_2_error_1(self):
         params = mm.ModelParameters(
             {'t_0_1': self.t_0_1, 'u_0_1': self.u_0_1, 't_0_2': self.t_0_2, 'u_0_2': self.u_0_2, 't_E': self.t_E})
         with self.assertRaises(KeyError):
             params.rho_2 = self.dummy_value
-            
+
     def test_set_rho_2_error_2(self):
         params = mm.ModelParameters(
             {'t_0_1': self.t_0_1, 'u_0_1': self.u_0_1, 'rho_1': self.rho_1,

--- a/source/MulensModel/tests/test_MulensSystem.py
+++ b/source/MulensModel/tests/test_MulensSystem.py
@@ -13,7 +13,7 @@ def test_mulenssystem_1():
     pi_rel = (lens['dist'].to(u.mas, equivalencies=u.parallax())
               - source['dist'].to(u.mas, equivalencies=u.parallax()))
     thetaE = np.sqrt(kappa * lens['mass'] * pi_rel)
-    tE = thetaE / mu_rel
+    tE = (thetaE / mu_rel).to(u.day).value
     pi_E = pi_rel / thetaE
 
     test_system = mm.MulensSystem(


### PR DESCRIPTION
I removed all astropy units and quantities from `modelparameters.py`, its tests and a few other parts.

There are still some units left for SkyCoord, for distances, parallaxes or other specific calculations.
@rpoleski, please let me know if I should undo any changes or apply to other missing.

The same 23 tests fail, as in the base Version3_1 branch.