### PR TITLE
Fixed bugs running two yaml files in example_16

### DIFF
--- a/examples/example_16/ob08092-o4_UN.yaml
+++ b/examples/example_16/ob08092-o4_UN.yaml
@@ -10,7 +10,7 @@ fit_constraints:
     prior:
         t_E: Mroz et al. 2020
 fitting_parameters:
-    log directory: outputs_ultranest/
+    log directory: ultranest_outputs/
     derived parameter names: flux_s_1 flux_b_1
     show_status: True
     n_live_points: 1000

--- a/examples/example_16/ulens_model_fit.py
+++ b/examples/example_16/ulens_model_fit.py
@@ -47,7 +47,7 @@ except Exception:
     raise ImportError('\nYou have to install MulensModel first!\n')
 
 
-__version__ = '0.44.1'
+__version__ = '0.44.2'
 
 
 class UlensModelFit(object):

--- a/examples/example_16/ulens_model_fit.py
+++ b/examples/example_16/ulens_model_fit.py
@@ -721,7 +721,7 @@ class UlensModelFit(object):
                 required_packages.add('corner')
 
         if self._plots is not None:
-            if self._plots['best model'] and 'interactive' in self._plots['best model']:
+            if 'interactive' in self._plots.get('best model', {}):
                 required_packages.add('plotly')
 
         failed = import_failed.intersection(required_packages)
@@ -3786,9 +3786,8 @@ class UlensModelFit(object):
         # the best model.
 
         self._reset_rcParams()
-        if 'rcParams' in self._plots['best model']:
-            for (key, value) in self._plots['best model']['rcParams'].items():
-                rcParams[key] = value
+        for (key, value) in self._plots['best model'].get('rcParams', {}).items():
+            rcParams[key] = value
 
         kwargs_all = self._get_kwargs_for_best_model_plot()
         (kwargs_grid, kwargs_model, kwargs, xlim, t_1, t_2) = kwargs_all[:6]
@@ -4167,9 +4166,8 @@ class UlensModelFit(object):
         self._ln_like(self._best_model_theta)  # Sets all parameters to the best model.
 
         self._reset_rcParams()
-        if 'rcParams' in self._plots['best model']:
-            for (key, value) in self._plots['best model']['rcParams'].items():
-                rcParams[key] = value
+        for (key, value) in self._plots['best model'].get('rcParams', {}).items():
+            rcParams[key] = value
 
         kwargs_all = self._get_kwargs_for_best_model_plot()
         (ylim, ylim_residuals) = self._get_ylim_for_best_model_plot(*kwargs_all[4:6])


### PR DESCRIPTION
Two commits to solve bugs running example_16 for:

- ob08092-o4_starting_file.yaml: `self._plots['best model']` caused error when best model is not requested. This and two other lines were adapted with the .get() method for dictionaries.
- ob08092-o4_UN.yaml: UltraNest was now included in the same `_ln_prior()` function, to not require checking the fitting method every time it gets called.

All the other yaml files work as expected in `data/expected_example_output`.
