### PR TITLE
Co magnif pl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+sandbox/
 
 # Byte-compiled / optimized 
 __pycache__/

--- a/source/MulensModel/magnificationcurve.py
+++ b/source/MulensModel/magnificationcurve.py
@@ -396,8 +396,8 @@ class MagnificationCurve(object):
             delta_t0 = delta_x * self.parameters.t_E * np.cos(
                 np.deg2rad(self.parameters.alpha))
             pspl = {key: value for key, value in self.parameters.parameters.items()}
-            pspl['t_0'] += delta_t0
-            pspl['u_0'] += delta_u0
+            pspl['t_0'] -= delta_t0
+            pspl['u_0'] -= delta_u0
             pspl_parameters = mm.ModelParameters(pspl)
 
         trajectory = self._setup_trajectory(selection, parameters=pspl_parameters)


### PR DESCRIPTION
Because of the offset between center of mass and center of magnification, the point_source_point_lens method is miscalculated for wide binaries with large q. 

For example,  using

logs=0.95
logq=-1.50
alpha=156.364

we can compare the point_source and point_source_point_lens methods:

<img width="1920" height="1440" alt="test_2L1S_mag_master" src="https://github.com/user-attachments/assets/c86290cd-e29c-46c2-9b4a-ae756f956bf4" />
<img width="1920" height="1440" alt="test_2L1S_diff_master" src="https://github.com/user-attachments/assets/7ade60a2-b3f7-43a1-8d9d-7cf8d54d175c" />

in the co_magnif_2L branch, I implemented a fix that transforms t_0 and u_0 to the appropriate origin before calculating the trajectory:

<img width="1920" height="1440" alt="test_2L1S_mag_co_magnif_2L" src="https://github.com/user-attachments/assets/4e75466f-be8d-411a-8862-2b19ab49a00e" />
<img width="1920" height="1440" alt="test_2L1S_diff_co_magnif_2L" src="https://github.com/user-attachments/assets/d03d5108-92ce-407a-8db7-d7f5bbb10682" />

There are still differences over the peak (due to the difference between 1L and 2L), but the offset and differences at large s due to the difference in magnification origin are fixed.
