### PR TITLE
Loosen test_int_input tolerance for native macOS arm64

### DIFF
--- a/source/MulensModel/tests/test_BinaryLens.py
+++ b/source/MulensModel/tests/test_BinaryLens.py
@@ -126,7 +126,7 @@ def test_int_input():
     lens_2 = mm.BinaryLensPointSourceMagnification(trajectory=trajectory_2)
     result_2 = lens_2.get_magnification()
 
-    np.testing.assert_almost_equal(result_1, result_2, decimal=13)
+    np.testing.assert_almost_equal(result_1, result_2, decimal=12)
 
 
 def test_BinaryLensVBMMagnification_1():


### PR DESCRIPTION
## Summary

`source/MulensModel/tests/test_BinaryLens.py::test_int_input` fails on **native macOS arm64** (Apple Silicon) by ~`1.94e-13` against the current `decimal=13` tolerance, while it still passes on the `ubuntu-latest` CI runner. This PR relaxes the tolerance to `decimal=12` (still ~`1e-12` absolute, well within VBMicrolensing's documented numerical accuracy) so the suite is green on both architectures.

## Reproduction

```
platform: macOS-26.2-arm64-arm-64bit (Apple Silicon)
python:   3.10.7
numpy:    2.2.6
scipy:    1.15.3
VBMicrolensing: 5.5
MulensModel:    3.9.3 (current master, 23036327)
```

Before this change:

```
=================================== FAILURES ===================================
________________________________ test_int_input ________________________________
>       np.testing.assert_almost_equal(result_1, result_2, decimal=13)
E       AssertionError:
E       Arrays are not almost equal to 13 decimals
E       Mismatched elements: 1 / 1 (100%)
E       Max absolute difference among violations: 1.93622895e-13
E       Max relative difference among violations: 1.29749686e-14
E        ACTUAL: array([14.922802595405])
E        DESIRED: array([14.9228025954048])
======================== 1 failed, 562 passed in 11.70s ========================
```

After this change: **563 passed, 0 failed**.

## Root cause

The test compares the magnification computed with `s=1.0` (Python float) vs `s=int(1)` cast inside `make_trajectory`. Both paths converge on the same input but invoke VBMicrolensing's binary-lens polynomial root finder via slightly different float construction. On **x86_64 Linux** the two calls happen to produce bit-identical results — there is no rounding gap, so `decimal=13` (and originally even `assert ==` in commit `2a813b06`) trivially holds. On **arm64** the same code path produces a result that differs in the last ~2 bits of the mantissa (~`2e-13` absolute, ~`1e-14` relative).

This is a well-known class of cross-architecture FP discrepancy:
- different SIMD primitives (SSE/AVX on x86 vs NEON on arm64),
- different FMA folding (Apple Silicon's libm aggressively uses fused multiply-add where x86 emits separate mul + add — which changes the final rounded bit),
- different `libm` implementations for transcendentals used inside the root finder.

The computed magnification value `14.9228025954048…` is physically identical on both platforms — the difference is in the last representable bit and has no observable consequence for any downstream model fit.

## Why this only surfaces now

Until #202 (Oct 2025, *Upgrade cibuildwheel to v3.2 and extend wheel platforms*) the macOS arm64 wheels for MulensModel were built via x86 emulation — so even users on M1/M2/M3 were effectively running x86 numerics. After #202 switched arm64 builds to native arm64 runners, the arm64 path became reachable on Apple Silicon, and the bit-level discrepancy started to materialise.

The test was introduced in `2a813b06` (Jan 2025) as `assert result_1 == result_2`, then loosened to `decimal=13` in `564f0293` (Dec 2025) during the VBBL → VBMicrolensing refactor. `decimal=13` was tight enough for x86 builds but does not survive native arm64.

## Why `decimal=12` is still strong

`decimal=12` asserts the two magnifications agree to ~`1e-12` absolute. VBMicrolensing's documented `Tol` default is `1e-2` and even its tightest `RelTol` is on the order of `1e-5`. A `1e-12` agreement between two *internal* code paths is therefore ~7 orders of magnitude tighter than any user-visible accuracy guarantee. The test still detects any real regression in the int → float coercion logic; it just no longer asserts bit-equivalence across CPU architectures.

## Suggested follow-up (not in this PR)

The current CI in `.github/workflows/python-app.yml` runs only on `ubuntu-latest`, which is why this regression went unnoticed upstream. Consider extending the matrix to also exercise Apple Silicon by switching `runs-on: ubuntu-latest` to a matrix over `[ubuntu-latest, macos-latest]` with `fail-fast: false`. `macos-latest` on GitHub Actions has been arm64 since late 2024 and is included in GitHub's free macOS minute quota for public repos. This would catch any future arm64-specific numerical drift in VBMicrolensing or AdaptiveContouring at PR time, instead of relying on individual users discovering it locally. Happy to send a separate PR for that if you'd like.

## Test plan

- [x] `pytest source/MulensModel/tests/test_BinaryLens.py::test_int_input` passes on macOS arm64 with this change
- [x] Full local suite: `563 passed in 11.45s` (was `562 passed, 1 failed`)
- [ ] CI on `ubuntu-latest` (existing workflow) — should remain green; the assertion is strictly weaker than before
