### PR TITLE
Fix: apply relative_accuracy on the no-LD VBM path (closes #162)

### DIFF
--- a/source/MulensModel/binarylens.py
+++ b/source/MulensModel/binarylens.py
@@ -576,6 +576,13 @@ class BinaryLensVBMMagnification(_BinaryLensPointSourceMagnification, _LimbDarke
         """
         Calculate 1 magnification using VBM.
         """
+        # RelTol must be set on the VBM instance for BOTH paths: BinaryMag
+        # (no LD) takes accuracy as a positional arg but still honors the
+        # RelTol property, while BinaryMag2 (with LD) reads both Tol and
+        # RelTol from the instance. Keeping this outside the if/else avoids
+        # the bug fixed in issue #162 where RelTol was applied only with LD.
+        if self._relative_accuracy is not None:
+            self._vbm.RelTol = self._relative_accuracy
         args = [float(separation), self._q, float(x), float(y), self._rho]
         if self._u_limb_darkening is None:
             args.append(self._accuracy)
@@ -583,9 +590,6 @@ class BinaryLensVBMMagnification(_BinaryLensPointSourceMagnification, _LimbDarke
             self._vbm.a1 = self._u_limb_darkening
             if self._accuracy is not None:
                 self._vbm.Tol = self._accuracy
-
-            if self._relative_accuracy is not None:
-                self._vbm.RelTol = self._relative_accuracy
 
         return self._vbm_function(*args)
 

--- a/source/MulensModel/tests/test_BinaryLens.py
+++ b/source/MulensModel/tests/test_BinaryLens.py
@@ -184,6 +184,30 @@ def test_BinaryLensVBMMagnification_reltol():
     np.testing.assert_almost_equal(result, 18.288975003)
 
 
+def test_BinaryLensVBMMagnification_reltol_no_LD():
+    """
+    Regression test for issue #162: relative_accuracy was previously not
+    propagated to VBMicrolensing on the no-limb-darkening path, so it had
+    no effect even though the parameter was accepted. With the fix, a
+    deliberately loose RelTol must produce a visibly different
+    magnification from a tight RelTol; if the parameter were still being
+    ignored (as before the fix), both calls would return identical values.
+    """
+    x = 0.0001
+    y = 0.0001
+    params = {'s': 1.1, 'q': 0.005, 'rho': 0.001}
+    trajectory = make_trajectory([x, y], params)
+    lens_tight = mm.BinaryLensVBMMagnification(
+        trajectory=trajectory, accuracy=1.e-2, relative_accuracy=1.e-10)
+    lens_loose = mm.BinaryLensVBMMagnification(
+        trajectory=trajectory, accuracy=1.e-2, relative_accuracy=0.5)
+    m_tight = lens_tight.get_magnification()
+    m_loose = lens_loose.get_magnification()
+    assert abs(m_tight[0] - m_loose[0]) > 0.01, (
+        "relative_accuracy has no effect on the no-LD path: "
+        "tight={!r}, loose={!r}".format(m_tight[0], m_loose[0]))
+
+
 def test_BinaryLensVBMMagnification_LD():
     """
     Make sure VBM with limb darkening works properly


### PR DESCRIPTION
Closes #162.

## Summary

`BinaryLensVBMMagnification.__init__` accepts `relative_accuracy` for all calling patterns (`source/MulensModel/binarylens.py:548-557`), but `_get_1_magnification` was forwarding it to VBMicrolensing **only when limb darkening was provided**. On the no-LD path (the default `BinaryMag` route, which is what users hit in the high-magnification case @zhangjiyuan22 reported) the parameter was silently ignored. This PR moves the `self._vbm.RelTol = self._relative_accuracy` assignment out of the `else` branch so it applies to both paths.

## Mutation evidence on `master`

High-mag scenario (`s=1.1, q=0.005, rho=0.001, x=y=0.0001`, magnification ~235):

| `relative_accuracy` | magnification on `master` |
|---|---|
| `None` | `235.1290414380` |
| `1e-10` | `235.1290414380` |
| `1e-3` | `235.1290414380` |
| `0.1` | `235.1290414380` |
| `0.5` | `235.1290414380` |

All identical to 10 decimals regardless of `relative_accuracy` — the parameter was being accepted by the constructor but never reaching VBMicrolensing.

After this PR:

| `relative_accuracy` | magnification | wall-clock (200 calls) |
|---|---|---|
| `None` (RelTol=0.0 default) | `235.129041` | 0.205 ms/call |
| `1e-10` | `235.129041` | 0.208 ms/call |
| `1e-3` | `235.149707` | 0.087 ms/call |
| `0.1` | `238.561329` | 0.024 ms/call (**8.5× speedup**) |
| `0.5` | `238.561329` | 0.022 ms/call |

This matches the 5×-10× speedup at magnification 100-200 that @zhangjiyuan22 plotted in #162.

## Why the no-LD path also honors `RelTol`

`VBMicrolensing.BinaryMag(s, q, x, y, rho, accuracy)` (no-LD) takes only the absolute `accuracy` as a positional argument, but verified by introspection that it still reads `self._vbm.RelTol` from the instance and applies it as a relative cutoff. The behavior is identical to `BinaryMag2` (with LD) in this respect. The bug in `master` was assuming that because no-LD doesn't have a `Tol` property assignment, it doesn't need a `RelTol` property assignment either — but only `Tol` is shadowed by the positional arg; `RelTol` is property-only.

## Implementation

```diff
 def _get_1_magnification(self, x, y, separation):
     """
     Calculate 1 magnification using VBM.
     """
+    # RelTol must be set on the VBM instance for BOTH paths: BinaryMag
+    # (no LD) takes accuracy as a positional arg but still honors the
+    # RelTol property, while BinaryMag2 (with LD) reads both Tol and
+    # RelTol from the instance. Keeping this outside the if/else avoids
+    # the bug fixed in issue #162 where RelTol was applied only with LD.
+    if self._relative_accuracy is not None:
+        self._vbm.RelTol = self._relative_accuracy
     args = [float(separation), self._q, float(x), float(y), self._rho]
     if self._u_limb_darkening is None:
         args.append(self._accuracy)
     else:
         self._vbm.a1 = self._u_limb_darkening
         if self._accuracy is not None:
             self._vbm.Tol = self._accuracy
-
-        if self._relative_accuracy is not None:
-            self._vbm.RelTol = self._relative_accuracy
     return self._vbm_function(*args)
```

The inline comment is there because the `master` form looks superficially "consistent with the LD-only `Tol` assignment" — without the note, the next refactor could plausibly re-introduce the bug.

`BinaryLensVBBLMagnification` (`binarylens.py:593`) is a back-compat alias that inherits from `BinaryLensVBMMagnification`, so the fix applies to both names automatically.

## Test

`test_BinaryLensVBMMagnification_reltol_no_LD` mirrors the existing `test_BinaryLensVBMMagnification_reltol` (which only covered the LD path) and asserts a structural property: a tight `RelTol` and a deliberately loose `RelTol` must produce visibly different magnifications. If `relative_accuracy` were silently ignored, both calls would return identical values (which is what `master` does on the high-mag scenario above).

The assertion uses a `> 0.01` threshold rather than a hard-coded numeric reference because VBMicrolensing's RelTol cutoff behavior may drift across versions; the structural property (loose ≠ tight) is what we actually care about for this regression.

## Test plan

- [x] New test passes locally with the fix: `pytest test_BinaryLens.py::test_BinaryLensVBMMagnification_reltol_no_LD` → 1 passed
- [x] Mutation verification: reverted the fix → new test fails with the diagnostic message `tight=235.12904143801455, loose=235.12904143801455`; re-applied the fix → test passes again
- [x] Full suite under `-W error::DeprecationWarning -W error::FutureWarning`: 563 passed, 0 new failures (the only failing test is the unrelated arm64 `test_int_input` addressed by PR #216)
- [x] Existing `test_BinaryLensVBMMagnification_reltol` (LD path) still passes — the fix does not regress the LD case
- [ ] CI on `ubuntu-latest` — should be green; logic change is strictly additive

