### PR TITLE
Warn when FitData.scale_fluxes() returns negative uncertainties (closes #81)

### DIFF
--- a/source/MulensModel/fitdata.py
+++ b/source/MulensModel/fitdata.py
@@ -497,6 +497,10 @@ class FitData(object):
             err_flux: *np.ndarray*
                 Uncertainties of fluxes from the data rescaled to the desired
                 system.
+
+        A ``UserWarning`` is emitted if ``err_flux`` contains negative
+        values, which can happen when ``source_flux`` or the fitted source
+        flux is negative.
         """
         if self.model.n_sources == 1:
             data_source_flux = self.source_flux
@@ -509,6 +513,15 @@ class FitData(object):
         flux /= data_source_flux
         flux += blend_flux
         err_flux = source_flux * self._dataset.err_flux / data_source_flux
+
+        if np.any(err_flux < 0.):
+            warnings.warn(
+                "FitData.scale_fluxes() produced negative flux "
+                "uncertainties. This happens when source_flux or the "
+                "fitted source flux is negative, which is unphysical and "
+                "usually indicates a problem with the model fit. "
+                "Downstream code may need to mask these values.",
+                UserWarning)
 
         return (flux, err_flux)
 

--- a/source/MulensModel/tests/test_FitData.py
+++ b/source/MulensModel/tests/test_FitData.py
@@ -505,6 +505,31 @@ def test_scale_fluxes():
     almost(exp_err / new_err, 1.)
 
 
+def test_scale_fluxes_negative_warning():
+    """
+    Regression test for issue #81: FitData.scale_fluxes() should emit a
+    UserWarning when it produces negative flux uncertainties. This happens
+    when source_flux (or the fitted source flux) is negative, which is
+    unphysical and users typically don't expect it. Before this fix the
+    function returned negative err_flux silently.
+    """
+    f_s = 1.0
+    f_b = 0.5
+    pspl, t, A = generate_model()
+    f_mod = f_s * A + f_b
+    data = generate_dataset(f_mod, t)
+    fit = mm.FitData(dataset=data, model=pspl)
+    fit.fit_fluxes()
+
+    # Negative source_flux propagates straight through to err_flux,
+    # producing negative values that should trigger the warning.
+    with pytest.warns(UserWarning, match="negative flux"):
+        (_, err_flux) = fit.scale_fluxes(source_flux=-1.0, blend_flux=0.)
+    assert np.any(err_flux < 0.), (
+        "test setup is broken: negative source_flux should produce "
+        "negative err_flux, got min={!r}".format(err_flux.min()))
+
+
 class TestGetResiduals(unittest.TestCase):
     """
     test get_residuals():


### PR DESCRIPTION
Closes #81.

## Summary

Per issue #81 (filed by @rpoleski 2023-02-24), `FitData.scale_fluxes()` can silently return **negative flux uncertainties** when `source_flux` or the fitted `data_source_flux` is negative. The arithmetic on `fitdata.py:511` is:

```python
err_flux = source_flux * self._dataset.err_flux / data_source_flux
```

`self._dataset.err_flux` is always non-negative, so the sign of the result follows the sign of `source_flux / data_source_flux`. Negative `err_flux` corrupts downstream plotting and statistics — and as the issue notes, users don't expect it.

This PR emits a `UserWarning` whenever the returned `err_flux` contains any negative element, matching the style of the existing flux-related warnings in `utils.py:114` and `utils.py:147`. The function's contract is otherwise unchanged (still returns `(flux, err_flux)`), so existing callers are not broken — they just now get a diagnostic when they hit the unphysical regime.

## Note on the second item in #81

The issue also asked for a `if np.sum(mask) == 0: continue` check in `UlensModelFit._get_ylim_for_best_model_plot()`. That check was already added by @rpoleski in commit `c07a5c06` ("ex16: minor bug in plotting") on **the same day the issue was filed** (`examples/example_16/ulens_model_fit.py:4273-4274`). So with this PR both items are resolved and #81 can be closed.

## Diff

`source/MulensModel/fitdata.py`:

```diff
         err_flux: *np.ndarray*
             Uncertainties of fluxes from the data rescaled to the desired
             system.
+
+    A ``UserWarning`` is emitted if ``err_flux`` contains negative
+    values, which can happen when ``source_flux`` or the fitted source
+    flux is negative.
     """
     ...
     err_flux = source_flux * self._dataset.err_flux / data_source_flux

+    if np.any(err_flux < 0.):
+        warnings.warn(
+            "FitData.scale_fluxes() produced negative flux "
+            "uncertainties. This happens when source_flux or the "
+            "fitted source flux is negative, which is unphysical and "
+            "usually indicates a problem with the model fit. "
+            "Downstream code may need to mask these values.",
+            UserWarning)
+
     return (flux, err_flux)
```

(`import warnings` was already at the top of the file.)

## Test

`source/MulensModel/tests/test_FitData.py::test_scale_fluxes_negative_warning` (new) drives the function with `source_flux=-1.0` and asserts both that the warning fires (with the expected message fragment) **and** that `err_flux` indeed contains negative elements — so the test does not silently pass on a regression where the function stops producing negative `err_flux`.

## Test plan

- [x] New test passes locally: `pytest test_FitData.py::test_scale_fluxes_negative_warning` → 1 passed
- [x] **Mutation-verified**: with the warning block reverted, the new test fails with `DID NOT WARN. No warnings of type (UserWarning,) were emitted`; re-applying the block makes it pass
- [x] `test_FitData.py` suite: 75 passed
- [x] Full local suite: 563 passed, 0 new failures (the only failing test is the unrelated arm64 `test_int_input` addressed by PR #216)
- [ ] CI on `ubuntu-latest` — should be green; the change is strictly additive (no signature change)

## API note

This is a behavior-visible change for users running with `-W error::UserWarning` who happened to pass negative `source_flux` and were previously unaware. That's the intended effect of the issue — the silent corruption was the bug, the warning is the fix.

