### PR TITLE
Mark unreachable n_lenses=3 arms as NotImplementedError + no-cover (#66)

### DIFF
--- a/source/MulensModel/model.py
+++ b/source/MulensModel/model.py
@@ -444,8 +444,9 @@ class Model(object):
             self._update_caustics_single_lens()
         elif self.n_lenses == 2:
             self._update_caustics_binary_lens(epoch)
-        else:
-            raise ValueError('updating triple lens caustics not yet coded')
+        else:  # pragma: no cover  (reserved for TripleLens, see issue #66)
+            raise NotImplementedError(
+                "triple lens caustics not yet implemented")
 
     def _update_caustics_single_lens(self):
         """
@@ -984,9 +985,10 @@ class Model(object):
         elif self.n_lenses == 2:
             methods_all_str = (
                 'point_source quadrupole hexadecapole vbm vbbl adaptive_contouring point_source_point_lens')
-        else:
-            msg = 'wrong value of Model.n_lenses: {:}'
-            raise ValueError(msg.format(self.n_lenses))
+        else:  # pragma: no cover  (reserved for TripleLens, see issue #66)
+            raise NotImplementedError(
+                "magnification method list for n_lenses={:} "
+                "not yet implemented".format(self.n_lenses))
 
         parameters = {key.lower(): value for (key, value) in methods_parameters.items()}
         methods_all = set([m.lower() for m in methods_all_str.split()])

--- a/source/MulensModel/tests/test_ModelParameters.py
+++ b/source/MulensModel/tests/test_ModelParameters.py
@@ -1827,3 +1827,29 @@ class test_Keplerian_elliptical(unittest.TestCase):
         dict_4 = setup_keplerian_elliptical({'s_z': 0.1, 'ds_z_dt': 1.9})
         with self.assertRaises(KeyError):
             mm.ModelParameters(dict_4)
+
+
+def test_n_lenses_invariant():
+    """
+    Issue #66: n_lenses is constrained to {1, 2} in master, which is what
+    makes the `else` arms on model.py:447 and model.py:988 unreachable
+    (and `# pragma: no cover`-marked). If a new path (e.g. TripleLens from
+    branch 3L_first) extends this, update both call sites and drop the
+    `pragma` markers.
+    """
+    single = [
+        {'t_0': 8000., 'u_0': 0.1, 't_E': 30.},
+        {'t_0': 8000., 'u_0': 0.1, 't_E': 30., 'rho': 0.001},
+        {'t_0': 8000., 'u_0': 0.1, 't_E': 30., 'pi_E_N': 0.1, 'pi_E_E': 0.2,
+         't_0_par': 8000.},
+    ]
+    binary = [
+        {'t_0': 8000., 'u_0': 0.1, 't_E': 30., 's': 1.1, 'q': 0.01,
+         'alpha': 90.},
+        {'t_0': 8000., 'u_0': 0.1, 't_E': 30., 's': 1.1, 'q': 0.01,
+         'alpha': 90., 'rho': 0.001},
+    ]
+    for params in single:
+        assert mm.ModelParameters(params).n_lenses == 1, params
+    for params in binary:
+        assert mm.ModelParameters(params).n_lenses == 2, params


### PR DESCRIPTION
Addresses #66.

Two `else` arms in `source/MulensModel/model.py` (`update_caustics()` line 447 and the magnification-methods list on line 988) raise for `n_lenses=3`. Both are unreachable today — `ModelParameters._count_lenses` only ever sets 1 or 2 — but kept as placeholders for the unmerged TripleLens work on branch `3L_first`.

This PR:

- swaps `ValueError` → `NotImplementedError` (semantically correct for "placeholder, not implemented yet"),
- marks both `else:` lines with `# pragma: no cover` so coverage stops flagging them as real gaps,
- adds `test_n_lenses_invariant` asserting `n_lenses ∈ {1, 2}`. When TripleLens lands and `_count_lenses` is extended, this test fails — surfacing both call sites at PR-review time, which is the "help find places that need corrections" outcome the issue thread asked for.

`NotImplementedError` inherits from `RuntimeError`, not `ValueError`. Grep shows no caller in repo or `examples/` catches these — they were never meant to be reached.

## Test plan

- [x] `test_n_lenses_invariant` passes locally
- [x] Mutation: monkey-patched `_count_lenses` to return 3 → test fails as expected
- [x] Full suite: 563 passed (562 baseline + 1 new), 0 regressions
