### PR TITLE
CI: add macos-arm to test matrix (requested in #216)

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -15,8 +15,16 @@ permissions:
 
 jobs:
   test:
-
-    runs-on: ubuntu-latest
+    name: test (${{ matrix.os }})
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      fail-fast: false # If false, continue with other matrix even if one fails
+      matrix:
+        include:
+          - os: linux-x86
+            runs-on: ubuntu-latest
+          - os: macos-arm
+            runs-on: macos-latest
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
As requested in #216 ("Please add the suggested PR.").

Switches the `test` job from a single `runs-on: ubuntu-latest` to a `fail-fast: false` matrix using the same `os/runs-on include` shape already established by `publish.yml`'s `build_wheels` job: `linux-x86` on `ubuntu-latest` (existing coverage) + `macos-arm` on `macos-latest` (new — arm64 native since late 2024). Other lines untouched.

Verification: YAML re-parses cleanly; matrix shape is structurally identical to the one in `publish.yml`. Actual cross-platform behaviour will be exercised by CI on this PR itself.
