### PR TITLE
Tests for LimbDarkeningCoeffs + fix get_weighted_limb_coeff_gamma (#65)

### DIFF
--- a/source/MulensModel/limbdarkeningcoeffs.py
+++ b/source/MulensModel/limbdarkeningcoeffs.py
@@ -118,7 +118,7 @@ class LimbDarkeningCoeffs(object):
         weight_sum = 0.
         for (band, weight) in weights.items():
             try:
-                gamma_sum += self.get_limb_coeff_gamma(band)
+                gamma_sum += weight * self.get_limb_coeff_gamma(band)
             except KeyError:
                 msg = "The bandpass {:} was not set for limb darkening"
                 raise KeyError(msg.format(band))

--- a/source/MulensModel/tests/test_LimbDarkeningCoeffs.py
+++ b/source/MulensModel/tests/test_LimbDarkeningCoeffs.py
@@ -1,0 +1,93 @@
+import unittest
+from numpy.testing import assert_almost_equal
+
+import MulensModel as mm
+
+
+class TestLimbDarkeningCoeffs(unittest.TestCase):
+    """
+    Unit tests for LimbDarkeningCoeffs — addresses the
+    `limbdarkeningcoeffs.py` checklist item in issue #65.
+    """
+    def setUp(self):
+        self.coeffs = mm.LimbDarkeningCoeffs()
+
+    def test_set_and_get_gamma(self):
+        self.coeffs.set_limb_coeff_gamma('I', 0.45)
+        self.assertEqual(self.coeffs.get_limb_coeff_gamma('I'), 0.45)
+
+    def test_set_and_get_u_round_trip(self):
+        self.coeffs.set_limb_coeff_u('I', 0.5)
+        assert_almost_equal(self.coeffs.get_limb_coeff_u('I'), 0.5)
+
+    def test_set_u_stored_as_gamma(self):
+        """set_limb_coeff_u converts via Utils.u_to_gamma before storing."""
+        self.coeffs.set_limb_coeff_u('I', 0.6)
+        assert_almost_equal(
+            self.coeffs.get_limb_coeff_gamma('I'),
+            mm.Utils.u_to_gamma(0.6))
+
+    def test_get_gamma_unknown_bandpass_raises(self):
+        with self.assertRaises(KeyError):
+            self.coeffs.get_limb_coeff_gamma('Z')
+
+    def test_get_u_unknown_bandpass_raises(self):
+        with self.assertRaises(KeyError):
+            self.coeffs.get_limb_coeff_u('Z')
+
+    def test_repr_contains_set_value(self):
+        self.coeffs.set_limb_coeff_gamma('I', 0.45)
+        text = repr(self.coeffs)
+        self.assertIn('I', text)
+        self.assertIn('0.45', text)
+
+
+class TestWeightedLimbCoeffGamma(unittest.TestCase):
+    """
+    Covers get_weighted_limb_coeff_gamma — the previously untested function
+    flagged in issue #65. The pre-fix implementation omitted the per-band
+    weight in the numerator (`gamma_sum += gamma` instead of
+    `gamma_sum += weight * gamma`), so unequal weights silently produced
+    the wrong value.
+    """
+    def setUp(self):
+        self.coeffs = mm.LimbDarkeningCoeffs()
+        self.coeffs.set_limb_coeff_gamma('I', 0.45)
+        self.coeffs.set_limb_coeff_gamma('V', 0.65)
+
+    def test_single_band(self):
+        assert_almost_equal(
+            self.coeffs.get_weighted_limb_coeff_gamma({'I': 1.0}), 0.45)
+
+    def test_equal_weights(self):
+        result = self.coeffs.get_weighted_limb_coeff_gamma(
+            {'I': 1., 'V': 1.})
+        assert_almost_equal(result, (0.45 + 0.65) / 2.)
+
+    def test_unequal_weights_proper_weighted_mean(self):
+        """
+        With weights I=1.5, V=1.0 the proper weighted mean is
+        (1.5*0.45 + 1.0*0.65) / (1.5 + 1.0) = 1.325 / 2.5 = 0.53.
+        Pre-fix the function returned (0.45 + 0.65) / 2.5 = 0.44.
+        """
+        result = self.coeffs.get_weighted_limb_coeff_gamma(
+            {'I': 1.5, 'V': 1.0})
+        assert_almost_equal(result, 0.53)
+
+    def test_non_dict_raises_type_error(self):
+        with self.assertRaises(TypeError):
+            self.coeffs.get_weighted_limb_coeff_gamma([('I', 1.0)])
+
+    def test_unset_band_raises_key_error(self):
+        with self.assertRaises(KeyError):
+            self.coeffs.get_weighted_limb_coeff_gamma({'Z': 1.0})
+
+    def test_empty_weights_raises_zero_division(self):
+        """Document current behavior: empty dict makes weight_sum == 0."""
+        with self.assertRaises(ZeroDivisionError):
+            self.coeffs.get_weighted_limb_coeff_gamma({})
+
+    def test_zero_total_weight_raises_zero_division(self):
+        """Document current behavior: weights summing to 0 hit 0-division."""
+        with self.assertRaises(ZeroDivisionError):
+            self.coeffs.get_weighted_limb_coeff_gamma({'I': 1.0, 'V': -1.0})


### PR DESCRIPTION
First batched-by-area PR for #65. Brings `limbdarkeningcoeffs.py` from 64% to 100% coverage (33/33 stmts) by adding `tests/test_LimbDarkeningCoeffs.py` with 13 tests in two `unittest.TestCase` classes.

## Suspected bug found while writing the tests

`get_weighted_limb_coeff_gamma` omits the per-band weight in the numerator:

```python
for (band, weight) in weights.items():
    gamma_sum += self.get_limb_coeff_gamma(band)   # weight ignored here
    weight_sum += weight
return gamma_sum / weight_sum
```

The docstring promises a proper weighted mean (`weights={'I': 1.5, 'V': 1.}` should make `I` contribute 1.5× more than `V`). With `gamma_I=0.45, gamma_V=0.65` the expected result is `(1.5*0.45 + 1.0*0.65) / 2.5 = 0.53`; the function returns `(0.45 + 0.65) / 2.5 = 0.44`.

History:
- Original commit `116117a4a` (2017-05-18) — the function had this shape from day one.
- Refactor `c9146c456` (2017-10-18) — rename only, logic untouched.
- Grep over `source/`, `examples/`, `docs/` finds **no callers** — the function is dead code internally, pure public API.

The one-word fix is included (`gamma_sum += weight * self.get_limb_coeff_gamma(band)`). **Please confirm this is genuinely a bug** and not an intentional formula I'm missing context for. If intentional, happy to drop the source change and adjust the test instead.

## Tests

- `TestLimbDarkeningCoeffs` (6 tests): set/get round-trips for `gamma` and `u`, `u → gamma` conversion check, `KeyError` on unknown bandpass for both getters, `repr`.
- `TestWeightedLimbCoeffGamma` (7 tests): single band, equal weights, **unequal weights → 0.53** (mutation-resistant — fails without the source fix with `ACTUAL: 0.44, DESIRED: 0.53`), `TypeError` on non-dict, `KeyError` on unset band, `ZeroDivisionError` on empty dict, `ZeroDivisionError` on weights summing to zero. The two `ZeroDivisionError` tests document current behavior, not endorse it — flagging in case it should later be replaced by `ValueError`.

## Potential follow-up (out of scope here)

While reviewing the area I noticed `MulensData.set_limb_darkening_weights()` (`mulensdata.py:564`) stores per-band weights but `FitData` reads only `dataset.bandpass`, never `_limb_darkening_weights` — looks like a separate integration gap, not something this PR should expand to.

## Test plan

- [x] `pytest test_LimbDarkeningCoeffs.py`: 13/13 passed
- [x] Mutation-verified: reverting the source change makes `test_unequal_weights_proper_weighted_mean` fail with `ACTUAL: 0.44, DESIRED: 0.53`; the other 12 tests still pass (they don't exercise the unequal-weights path).
- [x] Full suite: 577 passed (was 566), 0 regressions
- [x] Coverage: `limbdarkeningcoeffs.py` 64% → 100%
- [ ] CI on both matrix rows
