### PR TITLE
Tests for PlotUtils.get_y_value_y_err and find_subtract_xlabel (#65)

### DIFF
--- a/source/MulensModel/tests/test_Utils.py
+++ b/source/MulensModel/tests/test_Utils.py
@@ -1,7 +1,10 @@
-import numpy as np
 import os
+import unittest
+
+import numpy as np
 
 import MulensModel as mm
+from MulensModel.utils import PlotUtils
 
 
 SAMPLE_FILE_01 = os.path.join(
@@ -61,3 +64,74 @@ def test_n_caustics():
     assert mm.Utils.get_n_caustics(s=s_2, q=q) == 1
     assert mm.Utils.get_n_caustics(s=s_3, q=q) == 1
     assert mm.Utils.get_n_caustics(s=s_4, q=q) == 2
+
+
+class TestGetYValueYErr(unittest.TestCase):
+    """
+    Tests for PlotUtils.get_y_value_y_err — addresses the
+    `utils.py get_y_value_y_err()` checklist item in issue #65.
+    """
+    def setUp(self):
+        self.flux = np.array([1.0, 10.0, 100.0])
+        self.flux_err = np.array([0.01, 0.1, 1.0])
+
+    def test_flux_format_returns_inputs_unchanged(self):
+        (value, uncertainty) = PlotUtils.get_y_value_y_err(
+            'flux', self.flux, self.flux_err)
+        np.testing.assert_array_equal(value, self.flux)
+        np.testing.assert_array_equal(uncertainty, self.flux_err)
+
+    def test_mag_format_returns_hardcoded_magnitudes(self):
+        """
+        Hard-coded reference avoids defining the expected result through
+        the same conversion the SUT delegates to.
+        """
+        (value, uncertainty) = PlotUtils.get_y_value_y_err(
+            'mag', self.flux, self.flux_err)
+        # MAG_ZEROPOINT = 22.0, mag = 22 - 2.5 * log10(flux)
+        np.testing.assert_array_almost_equal(value, [22.0, 19.5, 17.0])
+        # 2.5/ln(10) * err/flux; flux/err is constant 100 for this input
+        np.testing.assert_array_almost_equal(
+            uncertainty, [0.010857362, 0.010857362, 0.010857362])
+
+    def test_unrecognized_format_raises_value_error(self):
+        with self.assertRaisesRegex(
+                ValueError, "Unrecognized photometry format"):
+            PlotUtils.get_y_value_y_err(
+                'magnitude', self.flux, self.flux_err)
+
+    def test_uppercase_mag_is_unrecognized(self):
+        """Case-sensitivity: only lowercase 'mag' / 'flux' are accepted."""
+        with self.assertRaisesRegex(
+                ValueError, "Unrecognized photometry format"):
+            PlotUtils.get_y_value_y_err('MAG', self.flux, self.flux_err)
+
+    def test_empty_arrays_flux_format(self):
+        (value, uncertainty) = PlotUtils.get_y_value_y_err(
+            'flux', np.array([]), np.array([]))
+        self.assertEqual(value.size, 0)
+        self.assertEqual(uncertainty.size, 0)
+
+
+class TestFindSubtractXlabel(unittest.TestCase):
+    """
+    Tests for PlotUtils.find_subtract_xlabel — addresses the
+    `utils.py find_subtract_xlabel()` checklist item in issue #65.
+    """
+    def test_default_returns_time(self):
+        self.assertEqual(PlotUtils.find_subtract_xlabel(), 'Time')
+
+    def test_subtract_2450000_returns_offset_label(self):
+        self.assertEqual(
+            PlotUtils.find_subtract_xlabel(subtract_2450000=True),
+            'Time - 2450000')
+
+    def test_subtract_2460000_returns_offset_label(self):
+        self.assertEqual(
+            PlotUtils.find_subtract_xlabel(subtract_2460000=True),
+            'Time - 2460000')
+
+    def test_both_subtract_flags_raise_value_error(self):
+        with self.assertRaisesRegex(ValueError, "cannot be both True"):
+            PlotUtils.find_subtract_xlabel(
+                subtract_2450000=True, subtract_2460000=True)


### PR DESCRIPTION
Next batched-by-area PR for #65 (after #222). Covers both `utils.py` items from the checklist:

- `PlotUtils.get_y_value_y_err()` — 5 tests covering `'flux'` and `'mag'` branches, `ValueError` on unrecognized format, `'MAG'` uppercase case-sensitivity, empty arrays.
- `PlotUtils.find_subtract_xlabel()` — 4 tests covering the default `'Time'` label, both single-flag branches, and `ValueError` when both flags are `True`.

9 new tests added to existing `test_Utils.py` in two `unittest.TestCase` classes (`TestGetYValueYErr`, `TestFindSubtractXlabel`).

The `'mag'` branch test asserts hard-coded magnitudes `[22.0, 19.5, 17.0]` (with `MAG_ZEROPOINT=22`) instead of deriving the expected via `Utils.get_mag_and_err_from_flux` (the same conversion that `get_y_value_y_err` itself calls internally). This avoids a tautological assertion where a regression in the conversion would silently slip through both sides.

## Potential follow-ups (out of scope here)

- `get_y_value_y_err`'s docstring says *"Any negative uncertainties are set to zero"*, but the implementation does not clip negatives in either branch. Looks like a docs-vs-code mismatch but I'd want a separate decision before touching either (mirrors the situation in #222).
- `PlotUtils.find_subtract` is the natural pair of `find_subtract_xlabel` and shares the same flag-conflict validation — could ride along, but #65 only flags `find_subtract_xlabel`, so leaving it for a separate batch unless you want it bundled.
- `PlotUtils.get_color_differences` and `PlotUtils.apply_defaults` need matplotlib mocking / `monkeypatch`-style fixtures, so separate batch.

## Test plan

- [x] `pytest test_Utils.py`: 14/14 passed (5 pre-existing + 9 new)
- [x] Full suite: 575 passed, 0 regressions
- [x] Coverage: `utils.py` 70% → 79% (the two functions in scope went from 0% to 100%)
- [ ] CI on both matrix rows

