### PR TITLE
Tests for CausticsBinary.critical_curve + constructor (#65)

### DIFF
--- a/source/MulensModel/tests/test_Caustics.py
+++ b/source/MulensModel/tests/test_Caustics.py
@@ -1,5 +1,7 @@
-import numpy as np
 import os
+import unittest
+
+import numpy as np
 
 import MulensModel as mm
 
@@ -33,3 +35,41 @@ def test_caustic():
             x[i], test_caustics['X'][index], decimal=5)
         np.testing.assert_almost_equal(
             y[i], test_caustics['Y'][index], decimal=5)
+
+
+class TestCriticalCurve(unittest.TestCase):
+    """
+    Tests for CausticsBinary.critical_curve — addresses the
+    `caustics.py critical_curve()` checklist item in issue #65.
+    """
+    def setUp(self):
+        self.caustics = mm.CausticsBinary(q=0.0053, s=0.548)
+
+    def test_critical_curve_returns_object_with_x_y_lists(self):
+        cc = self.caustics.critical_curve
+        self.assertIsInstance(cc.x, list)
+        self.assertIsInstance(cc.y, list)
+        self.assertEqual(len(cc.x), len(cc.y))
+        # n_points=5000 default -> n_angles ~1250, 4 roots each
+        self.assertEqual(len(cc.x), 5000)
+
+    def test_critical_curve_consistent_across_calls(self):
+        """Two accesses return the same x, y values."""
+        first = self.caustics.critical_curve
+        second = self.caustics.critical_curve
+        self.assertEqual(first.x, second.x)
+        self.assertEqual(first.y, second.y)
+
+
+class TestCausticsBinaryInit(unittest.TestCase):
+    """
+    Constructor edge cases for CausticsBinary.q (same area as #65 item
+    above; covers the q-as-list branch in __init__).
+    """
+    def test_q_as_single_element_list_is_accepted(self):
+        caustics = mm.CausticsBinary(q=[0.0053], s=0.548)
+        self.assertEqual(caustics.q, 0.0053)
+
+    def test_q_as_multi_element_list_raises_not_implemented(self):
+        with self.assertRaisesRegex(NotImplementedError, "Too many q"):
+            mm.CausticsBinary(q=[0.0053, 0.1], s=0.548)


### PR DESCRIPTION
Next batched-by-area PR for #65. Addresses the `caustics.py critical_curve()` checklist item — `caustics.py` was refactored to `causticsbinary.py` since the issue was filed; `critical_curve` is now the property at `causticsbinary.py:88`.

4 new tests added to existing `test_Caustics.py` in two `unittest.TestCase` classes:

- `TestCriticalCurve` (2 tests) — returns a `CriticalCurve` object with matching `x`/`y` lists of the expected length (5000 for default `n_points`), and consecutive accesses produce consistent values.
- `TestCausticsBinaryInit` (2 tests) — `q` as a single-element list is unpacked; `q` as a multi-element list raises `NotImplementedError`. Covers the same area (`causticsbinary.py:23-30`) which had no dedicated tests either.

Coverage of `causticsbinary.py`: **75% → 84%**. The only remaining uncovered block is `plot()` (lines 57-67), which needs matplotlib mocking — separate batch.

## Potential follow-up (out of scope here)

`CausticsBinary.get_caustics(n_points)` recomputes only when `self._x is None`, so a second call with a different `n_points` silently returns the cached result of the first call. `plot()` in the same class avoids this by also checking `len(self._x) != n_points` (`causticsbinary.py:59`). Same surface, inconsistent behavior — looks like a small bug worth its own fix PR if you'd like.

## Test plan

- [x] `pytest test_Caustics.py`: 5/5 passed (1 pre-existing + 4 new)
- [x] Full suite: 570 passed, 0 regressions
- [x] Coverage: `causticsbinary.py` 75% → 84%
- [ ] CI on both matrix rows
