### PR TITLE
Tests for SatelliteSkyCoord._check_times error path (#65)

### DIFF
--- a/source/MulensModel/tests/test_SatelliteSkyCoord.py
+++ b/source/MulensModel/tests/test_SatelliteSkyCoord.py
@@ -1,5 +1,8 @@
+import unittest
 from os.path import join
+
 import numpy as np
+from astropy.coordinates import SkyCoord
 
 import MulensModel as mm
 
@@ -25,3 +28,32 @@ def test_boundary():
     dec_2 = -23 - 26 / 60. - 38.2 / 3600.
     np.testing.assert_almost_equal(result_2.ra.value, ra_2, decimal=3)
     np.testing.assert_almost_equal(result_2.dec.value, dec_2, decimal=3)
+
+
+class TestCheckTimes(unittest.TestCase):
+    """
+    Tests for SatelliteSkyCoord._check_times — addresses the
+    `satelliteskycoord.py _check_times() - raise ValueError`
+    checklist item in issue #65. The ephemeris file used here covers
+    ~2456445 to ~2457328 (Spitzer 2013-2015).
+    """
+    def setUp(self):
+        ephemeris_file = join(
+            mm.DATA_PATH, 'ephemeris_files', 'Spitzer_ephemeris_01.dat')
+        self.satellite = mm.SatelliteSkyCoord(ephemeris_file)
+
+    def test_times_above_ephemeris_range_raise_value_error(self):
+        with self.assertRaisesRegex(
+                ValueError, "Satellite ephemeris doesn't cover"):
+            self.satellite.get_satellite_coords([2457500.0])
+
+    def test_times_below_ephemeris_range_raise_value_error(self):
+        with self.assertRaisesRegex(
+                ValueError, "Satellite ephemeris doesn't cover"):
+            self.satellite.get_satellite_coords([2456000.0])
+
+    def test_times_within_range_returns_skycoord(self):
+        times = [2456800.0, 2456900.0]
+        result = self.satellite.get_satellite_coords(times)
+        self.assertIsInstance(result, SkyCoord)
+        self.assertEqual(len(result), len(times))


### PR DESCRIPTION
Next batched-by-area PR for #65. Covers the `satelliteskycoord.py _check_times() - raise ValueError` checklist item.

3 new tests added to existing `test_SatelliteSkyCoord.py` in a `TestCheckTimes` class:

- `test_times_above_ephemeris_range_raise_value_error` — `times > max(ephemeris) + 3 min` raises `ValueError`
- `test_times_below_ephemeris_range_raise_value_error` — `times < min(ephemeris) - 3 min` raises `ValueError`
- `test_times_within_range_returns_skycoord` — in-range request returns a `SkyCoord` of the expected length (sanity check; the pre-existing `test_boundary` already pins specific RA/Dec values at the edge of the range)

Coverage of `satelliteskycoord.py`: **81% → 88%**. The remaining uncovered lines are `66-68` (astropy <4 fallback in `get_satellite_coords`) and `76-79` (`get_horizons` lazy init) — both outside the #65 checklist scope.

## Potential follow-up (out of scope here)

The error message in `_check_times` says `"Ephemerides file: {:} {:}"` but the formatted arguments are `min_, max_` — the ephemeris file path is never substituted. Looks like a small wording bug: either the message should say `"Ephemerides range: {:} {:}"` or the format args should include `self._ephemerides_file`. Happy to open a separate small PR for it.

## Test plan

- [x] `pytest test_SatelliteSkyCoord.py`: 4/4 passed (1 pre-existing + 3 new)
- [x] Full suite: 569 passed, 0 regressions
- [x] Coverage: `satelliteskycoord.py` 81% → 88%
- [ ] CI on both matrix rows
