### PR TITLE
Build wheels and sdist on pull requests; add experimental Windows wheels

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,8 @@ on:
     types: [published]
 #  push: # Acutal published is disabled in that case (see if in publish), but it runs build_wheels and send email if that fails.
 #    branches: [ "master" ]
+  pull_request: # Actual publish is disabled in that case (see if in publish), but it runs build_wheels and build_source so compilation problems are caught before merge.
+    branches: [ "master" ]
   workflow_dispatch:
     inputs:
       disable-publish:
@@ -20,6 +22,9 @@ jobs:
   build_wheels:
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.runs-on }}
+    # Experimental platforms (Windows, for now) cannot fail the workflow or
+    # block publish; their wheels are still uploaded if they do build.
+    continue-on-error: ${{ matrix.experimental || false }}
     strategy:
       fail-fast: false # If false, continue with other matrix even if one fails
       matrix:
@@ -32,7 +37,12 @@ jobs:
             runs-on: macos-15-intel
           - os: macos-arm
             runs-on: macos-latest
-# TO BE ADDED: windows-latest, windows-11-arm
+          - os: windows-x86
+            runs-on: windows-latest
+            experimental: true
+          - os: windows-arm
+            runs-on: windows-11-arm
+            experimental: true
 
     steps:
       - uses: actions/checkout@v4
@@ -72,9 +82,9 @@ jobs:
 
   publish:
     name: Publish to PyPI
-    # Skips if inputs.disable-publish is true or event is a push
+    # Skips if inputs.disable-publish is true or event is a pull_request
     #if: ${{ !(inputs.disable-publish || false) && github.event_name == 'push' }}
-    if: ${{ !(inputs.disable-publish || false)}}
+    if: ${{ github.event_name != 'pull_request' && !(inputs.disable-publish || false) }}
     runs-on: ubuntu-latest
     needs: [build_source, build_wheels]
 


### PR DESCRIPTION
This adds a `pull_request` trigger to `publish.yml` so that compilation problems in the C/C++ extensions are caught before merge, following the intent of the commented-out `push` trigger already in the file. On pull requests only `build_wheels` and `build_source` run; the `publish` job's `if` now also skips `pull_request` events, so release and `workflow_dispatch` behavior is unchanged.

It also promotes the `TO BE ADDED: windows-latest, windows-11-arm` note into experimental matrix entries. With `continue-on-error` these jobs cannot fail the workflow or block a publish, but if the Windows wheels do build, they are uploaded like the others (a quick scan of the VBBL/AdaptiveContouring sources found no obvious MSVC blockers — no VLAs, `unistd.h`, or other non-portable constructs — so they may just work). This PR's own checks will show how they fare, and the entries are easy to drop if unwanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)